### PR TITLE
refactor: load credentials from config module

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -1,5 +1,4 @@
-const { CLIENT_ID, GUILD_ID, TOKEN } = process.env;
-const creds = CLIENT_ID && GUILD_ID && TOKEN ? { clientId: CLIENT_ID, guildId: GUILD_ID, token: TOKEN } : require('./config.json');
+const { token, clientId, guildId } = require('./config');
 const Discord = require('discord.js');
 const fs = require('node:fs');
 const path = require('node:path');
@@ -126,14 +125,14 @@ function botMidnightLoop() {
 }
 botMidnightLoop();
 
-client.login(creds.token);
+client.login(token);
 
 function getClient() {
 	return client;
 }
 
 function getGuildID() {
-        return creds.guildId;
+        return guildId;
 }
 
 module.exports = { getClient, getGuildID };

--- a/deploy-commands.js
+++ b/deploy-commands.js
@@ -1,6 +1,5 @@
 const { REST, Routes, SlashCommandBuilder } = require('discord.js');
-const { CLIENT_ID, GUILD_ID, TOKEN } = process.env;
-const creds = CLIENT_ID && GUILD_ID && TOKEN ? { clientId: CLIENT_ID, guildId: GUILD_ID, token: TOKEN } : require('./config.json');
+const { token, clientId, guildId } = require('./config');
 const fs = require('node:fs');
 const path = require('node:path');
 const dbm = require('./database-manager');
@@ -51,18 +50,18 @@ async function loadCommands() {
 	// fs.writeFileSync('commandList.json', JSON.stringify(commandList, null, 2));
 
 	// Construct and prepare an instance of the REST module
-        const rest = new REST().setToken(creds.token);
+        const rest = new REST().setToken(token);
 
 	// and deploy your commands!
 	(async () => {
 		
 			console.log(`Started refreshing ${commands.length} application (/) commands.`);
 
-                        console.log(creds.clientId, creds.guildId);
+                        console.log(clientId, guildId);
 
 			// The put method is used to fully refresh all commands in the guild with the current set
 			const data = await rest.put(
-                                Routes.applicationGuildCommands(creds.clientId, creds.guildId),
+                                Routes.applicationGuildCommands(clientId, guildId),
 				{ body: commands },
 			);
 


### PR DESCRIPTION
## Summary
- load token, client ID, and guild ID from `config` module
- use imported credentials for REST setup and bot login

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68ab734e4748832eae0b2730fc912a22