### PR TITLE
refactor: centralize configuration usage

### DIFF
--- a/char.js
+++ b/char.js
@@ -3,7 +3,6 @@ const shop = require('./shop');
 const clientManager = require('./clientManager');
 const axios = require('axios');
 const { ActionRowBuilder, ButtonBuilder, ButtonStyle, EmbedBuilder, createWebhook } = require('discord.js');
-const { clientId, guildId } = require('./config.json');
 
 class char {
   static async warn(playerID) {

--- a/chatGPT.js
+++ b/chatGPT.js
@@ -1,13 +1,13 @@
 const OpenAI = require ('openai');
 const dbm = require('./database-manager');
 
-//Api key is in config.json, fourth element named gpt token. Grab it as constant
-const apiKey = require('./config.json').gptToken;
+// Load the API key from the shared configuration module
+const { gptToken: apiKey } = require('./config');
 //Format to work as gpt key
 //const apiToken = "Bearer " + apiKey;
 
 
-const openai = new OpenAI({apiKey: apiKey});
+const openai = new OpenAI({ apiKey });
 const Model3_5Turbo = "gpt-3.5-turbo";
 const Model4o = "gpt-4o";
 

--- a/deploy-commands.js
+++ b/deploy-commands.js
@@ -1,4 +1,4 @@
-const { REST, Routes, SlashCommandBuilder } = require('discord.js');
+const { REST, Routes } = require('discord.js');
 const { token, clientId, guildId } = require('./config');
 const fs = require('node:fs');
 const path = require('node:path');
@@ -57,13 +57,11 @@ async function loadCommands() {
 		
 			console.log(`Started refreshing ${commands.length} application (/) commands.`);
 
-                        console.log(clientId, guildId);
-
-			// The put method is used to fully refresh all commands in the guild with the current set
-			const data = await rest.put(
+                        // The put method is used to fully refresh all commands in the guild with the current set
+                        const data = await rest.put(
                                 Routes.applicationGuildCommands(clientId, guildId),
-				{ body: commands },
-			);
+                                { body: commands },
+                        );
 
 			console.log(`Successfully reloaded ${data.length} application (/) commands.`);
 		

--- a/interaction-handler.js
+++ b/interaction-handler.js
@@ -2,8 +2,6 @@ const shop = require('./shop');
 const char = require('./char');
 const marketplace = require('./marketplace');
 const admin = require('./admin');
-//Import guildID from config.json
-const { guildID } = require('./config.json');
 
 // MODALS
 addItem = async (interaction) => {


### PR DESCRIPTION
## Summary
- use shared config for REST credentials in command deployment script
- drop `config.json` imports from other modules
- load OpenAI token from config module

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ab745da37c832e856fe9eb3cae1a7f