### PR TITLE
Make GPT token optional in configuration

### DIFF
--- a/config.js
+++ b/config.js
@@ -50,7 +50,7 @@ function fromFile() {
 
 const config = { ...fromFile(), ...fromEnv() };
 
-const required = ['token', 'clientId', 'guildId', 'databaseUrl', 'gptToken'];
+const required = ['token', 'clientId', 'guildId', 'databaseUrl'];
 const missing = required.filter((key) => !config[key]);
 
 if (missing.length > 0) {


### PR DESCRIPTION
## Summary
- Remove gptToken from required configuration array
- Ensure config spread keeps gptToken available but optional

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ab82aa095c832e914db31e5fc7e521