### PR TITLE
Add ship catalog codex and initializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # Merlin Serski
- 
+
+## Ship Catalog
+
+Ship definitions for the game are stored in `jsonStorage/shipCatalog.json` and
+loaded into the database via `initShipCatalog.js`. After deploying, run:
+
+```
+node initShipCatalog.js
+```
+
+This will save the `shipCatalog` collection to your Railway database so other
+modules can query ship stats. To update ship balance, edit
+`shipCatalog.json` and rerun the script.
+
+Game logic should reference ship stats through the catalog using
+`dbm.loadCollection('shipCatalog')` rather than duplicating attack, defense,
+speed or HP on individual inventory entries.
+

--- a/char.js
+++ b/char.js
@@ -3,6 +3,7 @@ const shop = require('./shop');
 const clientManager = require('./clientManager');
 const axios = require('axios');
 const { ActionRowBuilder, ButtonBuilder, ButtonStyle, EmbedBuilder, createWebhook } = require('discord.js');
+const shipUtils = require('./shipUtils');
 
 class char {
   static async warn(playerID) {
@@ -55,6 +56,7 @@ class char {
         inventory: {
           "Adventure Token": 1
         },
+        fleet: {},
         incomeList: {},
         incomeAvailable: true,
         stats: {
@@ -215,6 +217,24 @@ class char {
     } else {
       return "You haven't made a character! Use /newchar first";
     }
+  }
+
+  static async fleetPower(userID) {
+    const collectionName = 'characters';
+    const charData = await dbm.loadFile(collectionName, userID);
+    if (!charData) {
+      return "You haven't made a character! Use /newchar first";
+    }
+    const totals = await shipUtils.calculateFleetPower(charData.fleet || {});
+    return totals;
+  }
+
+  static async shipStats(shipName) {
+    const stats = await shipUtils.getShipStats(shipName);
+    if (!stats) {
+      return 'Ship not found';
+    }
+    return stats;
   }
 
   static async char(userID) {

--- a/initShipCatalog.js
+++ b/initShipCatalog.js
@@ -1,0 +1,12 @@
+const dbm = require('./database-manager');
+const fs = require('fs');
+const path = require('path');
+
+async function initShipCatalog() {
+  const catalogPath = path.join(__dirname, 'jsonStorage', 'shipCatalog.json');
+  const catalog = JSON.parse(fs.readFileSync(catalogPath, 'utf-8'));
+  await dbm.saveCollection('shipCatalog', catalog);
+  console.log('shipCatalog saved to DB');
+}
+
+initShipCatalog().catch(console.error);

--- a/jsonStorage/shipCatalog.json
+++ b/jsonStorage/shipCatalog.json
@@ -1,0 +1,6 @@
+{
+  "Corvette": { "tier": 1, "attack": 45, "defense": 25, "speed": 90, "hp": 300 },
+  "Destroyer": { "tier": 2, "attack": 70, "defense": 55, "speed": 65, "hp": 550 },
+  "Heavy Frigate": { "tier": 3, "attack": 90, "defense": 75, "speed": 45, "hp": 800 },
+  "Cruiser": { "tier": 4, "attack": 130, "defense": 90, "speed": 35, "hp": 1200 }
+}

--- a/shipUtils.js
+++ b/shipUtils.js
@@ -1,0 +1,27 @@
+const dbm = require('./database-manager');
+
+async function loadShipCatalog() {
+  return await dbm.loadCollection('shipCatalog');
+}
+
+async function getShipStats(shipName) {
+  const catalog = await loadShipCatalog();
+  return catalog[shipName] || null;
+}
+
+async function calculateFleetPower(fleet = {}) {
+  const catalog = await loadShipCatalog();
+  const totals = { attack: 0, defense: 0, speed: 0, hp: 0 };
+  for (const [shipName, count] of Object.entries(fleet)) {
+    const stats = catalog[shipName];
+    if (stats && count > 0) {
+      totals.attack += stats.attack * count;
+      totals.defense += stats.defense * count;
+      totals.speed += stats.speed * count;
+      totals.hp += stats.hp * count;
+    }
+  }
+  return totals;
+}
+
+module.exports = { loadShipCatalog, getShipStats, calculateFleetPower };


### PR DESCRIPTION
## Summary
- add JSON ship catalog and script to persist it via database-manager
- provide helper to load ship stats and compute fleet totals
- document catalog initialization in README

## Testing
- `node initShipCatalog.js` *(fails: Missing required configuration: token, clientId, guildId, databaseUrl)*
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68ad8c3d01b8832e89d46410a92bc0d5