### PR TITLE
feat: add raid command and battle simulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,20 @@ Game logic should reference ship stats through the catalog using
 `dbm.loadCollection('shipCatalog')` rather than duplicating attack, defense,
 speed or HP on individual inventory entries.
 
+## Raid Command
+
+The `/raid` command lets players send ships from their personal fleet to attack
+one of several predefined targets. Raid target templates live in
+`jsonStorage/raidTargets.json` and define enemy power, loot ranges and casualty
+scaling. Adjust these numbers to tune difficulty or rewards.
+
+Raid resolution uses `raidUtils.js`, which in turn pulls ship stats from the
+shared `shipCatalog` via `shipUtils.loadShipCatalog()`. Tuning constants like
+stat weights and roll variance are collected at the top of `raidUtils.js` so
+they can be tweaked without touching simulation logic.
+
+After every raid the player's ship inventory is updated with losses, loot is
+granted, and a log entry is written to the `raidLog` collection for later
+analysis. A short cooldown prevents spamming the command. Session state is kept
+in-memory but can be swapped for Redis in production.
+

--- a/bot.js
+++ b/bot.js
@@ -19,20 +19,30 @@ const client = new Client({
 //sets up usage of commands from command folder
 client.commands = new Collection();
 const foldersPath = path.join(__dirname, 'commands');
-const commandFolders = fs.readdirSync(foldersPath);
+const entries = fs.readdirSync(foldersPath, { withFileTypes: true });
 
-for (const folder of commandFolders) {
-	const commandsPath = path.join(foldersPath, folder);
-	const commandFiles = fs.readdirSync(commandsPath).filter(file => file.endsWith('.js'));
-	for (const file of commandFiles) {
-		const filePath = path.join(commandsPath, file);
-		const command = require(filePath);
-		if ('data' in command && 'execute' in command) {
-			client.commands.set(command.data.name, command);
-		} else {
-			console.log(`[WARNING] The command at ${filePath} is missing a required "data" or "execute" property.`);
-		}
-	}
+for (const entry of entries) {
+        if (entry.isDirectory()) {
+                const commandsPath = path.join(foldersPath, entry.name);
+                const commandFiles = fs.readdirSync(commandsPath).filter(file => file.endsWith('.js'));
+                for (const file of commandFiles) {
+                        const filePath = path.join(commandsPath, file);
+                        const command = require(filePath);
+                        if ('data' in command && 'execute' in command) {
+                                client.commands.set(command.data.name, command);
+                        } else {
+                                console.log(`[WARNING] The command at ${filePath} is missing a required "data" or "execute" property.`);
+                        }
+                }
+        } else if (entry.isFile() && entry.name.endsWith('.js')) {
+                const filePath = path.join(foldersPath, entry.name);
+                const command = require(filePath);
+                if ('data' in command && 'execute' in command) {
+                        client.commands.set(command.data.name, command);
+                } else {
+                        console.log(`[WARNING] The command at ${filePath} is missing a required "data" or "execute" property.`);
+                }
+        }
 }
 
 client.on('ready', () => {

--- a/clientManager.js
+++ b/clientManager.js
@@ -1,4 +1,24 @@
 class clientManager {
+    // simple in-memory raid session store
+    static raidSessions = new Map();
+
+    static getRaidSession(userID) {
+        const session = this.raidSessions.get(userID);
+        if (session && session.expiresAt > Date.now()) {
+            return session;
+        }
+        this.raidSessions.delete(userID);
+        return null;
+    }
+
+    static setRaidSession(userID, data) {
+        const expiresAt = Date.now() + 5 * 60 * 1000; // 5 minutes
+        this.raidSessions.set(userID, { ...data, expiresAt });
+    }
+
+    static clearRaidSession(userID) {
+        this.raidSessions.delete(userID);
+    }
     static getEmoji(emojiName) {
         const bot = require('./bot');
 

--- a/commands/raid.js
+++ b/commands/raid.js
@@ -1,0 +1,148 @@
+const { SlashCommandBuilder, StringSelectMenuBuilder, ActionRowBuilder, ComponentType, EmbedBuilder } = require('discord.js');
+const raidUtils = require('../raidUtils');
+const dbm = require('../database-manager');
+const clientManager = require('../clientManager');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('raid')
+    .setDescription('Launch a raid against one of the available targets'),
+  async execute(interaction) {
+    const userId = interaction.user.id;
+    const charId = interaction.user.tag;
+
+    const charData = await dbm.loadFile('characters', charId);
+    if (!charData) {
+      await interaction.reply({ content: 'Create a character first with /newchar.', ephemeral: true });
+      return;
+    }
+
+    const now = Date.now();
+    const COOLDOWN = 60 * 60 * 1000; // 1 hour
+    if (charData.lastRaidAt && now - charData.lastRaidAt < COOLDOWN) {
+      const mins = Math.ceil((COOLDOWN - (now - charData.lastRaidAt)) / 60000);
+      await interaction.reply({ content: `You must wait ${mins} more minutes before raiding again.`, ephemeral: true });
+      return;
+    }
+
+    const targets = await raidUtils.loadRaidTargets();
+    const targetOptions = Object.keys(targets).map(key => ({ label: key, value: key }));
+    const targetMenu = new StringSelectMenuBuilder()
+      .setCustomId('raidTarget')
+      .setPlaceholder('Select a target')
+      .addOptions(targetOptions);
+    await interaction.reply({ content: 'Choose a raid target', components: [new ActionRowBuilder().addComponents(targetMenu)], ephemeral: true });
+
+    const filter = i => i.user.id === userId;
+    let targetInteraction;
+    try {
+      targetInteraction = await interaction.awaitMessageComponent({ filter, componentType: ComponentType.StringSelect, time: 60000 });
+    } catch (err) {
+      return;
+    }
+
+    const targetKey = targetInteraction.values[0];
+    clientManager.setRaidSession(userId, { selectedTarget: targetKey });
+    const fleet = charData.fleet || {};
+    const shipOptions = Object.entries(fleet)
+      .filter(([ship, count]) => count > 0)
+      .map(([ship, count]) => ({ label: `${ship} (${count})`, value: ship }));
+    if (shipOptions.length === 0) {
+      await targetInteraction.update({ content: 'You have no ships to deploy.', components: [] });
+      clientManager.clearRaidSession(userId);
+      return;
+    }
+
+    const shipMenu = new StringSelectMenuBuilder()
+      .setCustomId('raidShips')
+      .setPlaceholder('Select ships to send')
+      .setMinValues(1)
+      .setMaxValues(shipOptions.length)
+      .addOptions(shipOptions);
+    await targetInteraction.update({ content: `Target **${targetKey}** selected. Choose ships to deploy.`, components: [new ActionRowBuilder().addComponents(shipMenu)] });
+
+    let shipInteraction;
+    try {
+      shipInteraction = await interaction.awaitMessageComponent({ filter, componentType: ComponentType.StringSelect, time: 60000 });
+    } catch (err) {
+      clientManager.clearRaidSession(userId);
+      return;
+    }
+
+    const selectedShips = shipInteraction.values;
+    await shipInteraction.update({ content: `Enter quantities for each ship in the format "Ship:Amount" separated by commas.`, components: [] });
+
+    const msgFilter = m => m.author.id === userId;
+    const collected = await interaction.channel.awaitMessages({ filter: msgFilter, max: 1, time: 60000 });
+    if (collected.size === 0) {
+      clientManager.clearRaidSession(userId);
+      return;
+    }
+
+    const response = collected.first().content;
+    const fleetSelection = {};
+    response.split(',').forEach(part => {
+      const [name, qty] = part.split(':').map(t => t.trim());
+      const n = parseInt(qty, 10);
+      if (name && !isNaN(n)) fleetSelection[name] = n;
+    });
+
+    clientManager.setRaidSession(userId, { selectedTarget: targetKey, fleetSelection });
+
+    for (const [ship, qty] of Object.entries(fleetSelection)) {
+      if (!fleet[ship] || fleet[ship] < qty) {
+        await interaction.followUp({ content: `You do not have enough ${ship}.`, ephemeral: true });
+        clientManager.clearRaidSession(userId);
+        return;
+      }
+    }
+
+    const weights = raidUtils.DEFAULT_WEIGHTS;
+    const variance = 0.1;
+    const sim = await raidUtils.simulateBattle(fleetSelection, targets[targetKey], weights, variance);
+
+    for (const [ship, lost] of Object.entries(sim.casualties)) {
+      fleet[ship] -= lost;
+      if (fleet[ship] <= 0) delete fleet[ship];
+    }
+    charData.fleet = fleet;
+
+    if (sim.result !== 'loss') {
+      for (const [res, amt] of Object.entries(sim.loot)) {
+        if (res === 'credits' || res === 'gold') {
+          charData.balance = (charData.balance || 0) + amt;
+        } else {
+          if (!charData.inventory) charData.inventory = {};
+          charData.inventory[res] = (charData.inventory[res] || 0) + amt;
+        }
+      }
+    }
+
+    charData.lastRaidAt = now;
+    await dbm.saveFile('characters', charId, charData);
+
+    await dbm.saveFile('raidLog', `${userId}-${now}`, {
+      user: charId,
+      target: targetKey,
+      fleet: fleetSelection,
+      rolls: sim.rolls,
+      result: sim.result,
+      loot: sim.loot,
+      casualties: sim.casualties,
+      timestamp: new Date(now).toISOString(),
+    });
+
+    const embed = new EmbedBuilder()
+      .setTitle(`Raid ${sim.result.toUpperCase()}`)
+      .setColor(sim.result === 'win' ? 0x00ff00 : sim.result === 'pyrrhic' ? 0xffa500 : 0xff0000)
+      .addFields(
+        { name: 'Enemy Roll', value: sim.rolls.enemy.toFixed(2), inline: true },
+        { name: 'Your Roll', value: sim.rolls.player.toFixed(2), inline: true },
+      )
+      .addFields({ name: 'Loot', value: Object.entries(sim.loot).map(([k, v]) => `${k}: ${v}`).join('\n') || 'None' })
+      .addFields({ name: 'Casualties', value: Object.entries(sim.casualties).map(([k, v]) => `${k}: ${v}`).join('\n') || 'None' });
+
+    await interaction.followUp({ embeds: [embed], ephemeral: true });
+    clientManager.clearRaidSession(userId);
+  },
+};

--- a/deploy-commands.js
+++ b/deploy-commands.js
@@ -7,36 +7,33 @@ const { map } = require('./admin');
 
 
 async function loadCommands() {
-	const commands = [];
-	// Grab all the command folders from the commands directory you created earlier
-	const foldersPath = path.join(__dirname, 'commands');
-	const commandFolders = fs.readdirSync(foldersPath);
+        const commands = [];
+        const foldersPath = path.join(__dirname, 'commands');
+        const entries = fs.readdirSync(foldersPath, { withFileTypes: true });
 
-	let commandList = {};
-
-
-	for (const folder of commandFolders) {
-		// Grab all the command files from the commands directory you created earlier
-		const commandsPath = path.join(foldersPath, folder);
-		const commandFiles = fs.readdirSync(commandsPath).filter(file => file.endsWith('.js'));
-
-		//Count command files, print, and than break
-		let count = 0;
-		for (const file of commandFiles) {
-			count++;
-		}
-		// Grab the SlashCommandBuilder#toJSON() output of each command's data for deployment
-		for (const file of commandFiles) {
-			//Add this command to the list of commands with fields "name", "description" and "help"
-			const filePath = path.join(commandsPath, file);
-			const command = require(filePath);
-			if ('data' in command && 'execute' in command) {
-				commands.push(command.data.toJSON());
-			} else {
-				console.log(`[WARNING] The command at ${filePath} is missing a required "data" or "execute" property.`);
-			}
-		}
-	}
+        for (const entry of entries) {
+                if (entry.isDirectory()) {
+                        const commandsPath = path.join(foldersPath, entry.name);
+                        const commandFiles = fs.readdirSync(commandsPath).filter(file => file.endsWith('.js'));
+                        for (const file of commandFiles) {
+                                const filePath = path.join(commandsPath, file);
+                                const command = require(filePath);
+                                if ('data' in command && 'execute' in command) {
+                                        commands.push(command.data.toJSON());
+                                } else {
+                                        console.log(`[WARNING] The command at ${filePath} is missing a required "data" or "execute" property.`);
+                                }
+                        }
+                } else if (entry.isFile() && entry.name.endsWith('.js')) {
+                        const filePath = path.join(foldersPath, entry.name);
+                        const command = require(filePath);
+                        if ('data' in command && 'execute' in command) {
+                                commands.push(command.data.toJSON());
+                        } else {
+                                console.log(`[WARNING] The command at ${filePath} is missing a required "data" or "execute" property.`);
+                        }
+                }
+        }
 
 	// dbm.saveFile('keys', 'commandList', commandList, (err, result) => {
 	//     if (err) {

--- a/jsonStorage/raidTargets.json
+++ b/jsonStorage/raidTargets.json
@@ -1,0 +1,6 @@
+{
+  "easy":    { "enemyPower": 100, "loot": { "credits": [10, 50], "alloys": [2, 5] }, "lossFactor": 0.5 },
+  "medium":  { "enemyPower": 200, "loot": { "credits": [50, 100], "alloys": [5, 10] }, "lossFactor": 0.7 },
+  "hard":    { "enemyPower": 300, "loot": { "credits": [100, 200], "alloys": [10, 20] }, "lossFactor": 0.9 },
+  "extreme": { "enemyPower": 500, "loot": { "credits": [200, 400], "alloys": [20, 40] }, "lossFactor": 1.2 }
+}

--- a/raidUtils.js
+++ b/raidUtils.js
@@ -1,0 +1,106 @@
+const shipUtils = require('./shipUtils');
+const dbm = require('./database-manager');
+
+// Default tuning constants
+const DEFAULT_WEIGHTS = {
+  attack: 1,
+  defense: 1,
+  hp: 0.5,
+  speed: 0.2,
+  tier: 5,
+};
+
+function randomRange(min, max) {
+  return Math.random() * (max - min) + min;
+}
+
+async function loadRaidTargets() {
+  return await dbm.loadCollection('raidTargets');
+}
+
+function rollPower(basePower, variancePercent = 0) {
+  const variance = variancePercent;
+  const delta = randomRange(-variance, variance);
+  return basePower * (1 + delta);
+}
+
+async function calculateFleetPowerWeighted(fleet = {}, weights = DEFAULT_WEIGHTS) {
+  const catalog = await shipUtils.loadShipCatalog();
+  let totals = { attack: 0, defense: 0, speed: 0, hp: 0, tier: 0 };
+  for (const [shipName, count] of Object.entries(fleet)) {
+    const stats = catalog[shipName];
+    if (stats && count > 0) {
+      totals.attack += stats.attack * count;
+      totals.defense += stats.defense * count;
+      totals.speed += stats.speed * count;
+      totals.hp += stats.hp * count;
+      totals.tier += (stats.tier || 0) * count;
+    }
+  }
+  const power =
+    totals.attack * (weights.attack || 0) +
+    totals.defense * (weights.defense || 0) +
+    totals.hp * (weights.hp || 0) +
+    totals.speed * (weights.speed || 0) +
+    totals.tier * (weights.tier || 0);
+  return power;
+}
+
+async function simulateBattle(fleet, target, weights = DEFAULT_WEIGHTS, variance = 0.1) {
+  const basePlayerPower = await calculateFleetPowerWeighted(fleet, weights);
+  const playerRoll = rollPower(basePlayerPower, variance);
+  const enemyRoll = rollPower(target.enemyPower, variance);
+  const rolls = { player: playerRoll, enemy: enemyRoll };
+
+  const pressure = enemyRoll / Math.max(playerRoll, 1);
+  const margin = (playerRoll - enemyRoll) / enemyRoll;
+
+  let result = 'loss';
+  if (playerRoll >= enemyRoll) {
+    result = pressure > 0.8 ? 'pyrrhic' : 'win';
+  }
+
+  const catalog = await shipUtils.loadShipCatalog();
+  const totalHp = Object.entries(fleet).reduce((sum, [name, count]) => {
+    const stats = catalog[name];
+    return sum + (stats ? stats.hp * count : 0);
+  }, 0);
+
+  let casualtyRate;
+  if (result === 'win') {
+    casualtyRate = pressure * 0.2;
+  } else if (result === 'pyrrhic') {
+    casualtyRate = pressure * 0.5;
+  } else {
+    casualtyRate = pressure * (target.lossFactor || 1);
+  }
+
+  const casualties = {};
+  for (const [name, count] of Object.entries(fleet)) {
+    const stats = catalog[name];
+    if (!stats) continue;
+    const hpShare = totalHp > 0 ? (stats.hp * count) / totalHp : 0;
+    const lost = Math.min(count, Math.round(count * casualtyRate * hpShare));
+    if (lost > 0) casualties[name] = lost;
+  }
+
+  const loot = {};
+  if (result !== 'loss') {
+    for (const [resource, range] of Object.entries(target.loot || {})) {
+      const [min, max] = range;
+      const base = Math.floor(randomRange(min, max + 1));
+      const scaled = Math.max(0, Math.round(base * (1 + Math.max(0, margin))));
+      loot[resource] = scaled;
+    }
+  }
+
+  return { result, loot, casualties, rolls };
+}
+
+module.exports = {
+  loadRaidTargets,
+  rollPower,
+  calculateFleetPowerWeighted,
+  simulateBattle,
+  DEFAULT_WEIGHTS,
+};


### PR DESCRIPTION
## Summary
- add static raid target definitions and utilities for battle simulation
- introduce in-memory raid session tracking and `/raid` slash command
- load new command in bot/deploy flow and document raid system

## Testing
- `npm test` *(fails: Missing script "test")*
- `node -e "require('./raidUtils'); console.log('raidUtils loaded')"` *(fails: Missing required configuration: token, clientId, guildId, databaseUrl)*

------
https://chatgpt.com/codex/tasks/task_e_68ad9f5892a4832eaf0a252c494f22d2