### PR TITLE
feat: add battleship to ship catalog

### DIFF
--- a/jsonStorage/shipCatalog.json
+++ b/jsonStorage/shipCatalog.json
@@ -2,5 +2,6 @@
   "Corvette": { "tier": 1, "attack": 45, "defense": 25, "speed": 90, "hp": 300 },
   "Destroyer": { "tier": 2, "attack": 70, "defense": 55, "speed": 65, "hp": 550 },
   "Heavy Frigate": { "tier": 3, "attack": 90, "defense": 75, "speed": 45, "hp": 800 },
-  "Cruiser": { "tier": 4, "attack": 130, "defense": 90, "speed": 35, "hp": 1200 }
+  "Cruiser": { "tier": 4, "attack": 130, "defense": 90, "speed": 35, "hp": 1200 },
+  "Battleship": { "tier": 5, "attack": 170, "defense": 110, "speed": 25, "hp": 1800 }
 }


### PR DESCRIPTION
## Summary
- add Battleship entry to ship catalog
- keep ship catalog formatting compact

## Testing
- `TOKEN=foo CLIENT_ID=bar GUILD_ID=baz DATABASE_URL=postgres://user:pass@localhost/db node initShipCatalog.js`
- `TOKEN=foo CLIENT_ID=bar GUILD_ID=baz DATABASE_URL=postgres://user:pass@localhost/db node -e "const shipUtils=require('./shipUtils'); shipUtils.loadShipCatalog().then(c=>{console.log(Object.keys(c));});"`


------
https://chatgpt.com/codex/tasks/task_e_68ada9f3532c832e85f33acbcee09421