### PR TITLE
Add raid targets initialization script

### DIFF
--- a/initRaidTargets.js
+++ b/initRaidTargets.js
@@ -1,0 +1,17 @@
+const dbm = require('./database-manager');
+const fs = require('fs');
+const path = require('path');
+
+async function initRaidTargets() {
+  // Read the JSON file you created under jsonStorage
+  const filePath = path.join(__dirname, 'jsonStorage', 'raidTargets.json');
+  const targets = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+
+  // Save the entire object to the 'raidTargets' collection
+  await dbm.saveCollection('raidTargets', targets);
+  console.log('raidTargets saved to DB');
+}
+
+initRaidTargets().catch((err) => {
+  console.error(err);
+});


### PR DESCRIPTION
## Summary
- add `initRaidTargets.js` to load raid target data into the database

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ade97d4fd8832e97487a2ca92daa5d