### PR TITLE
feat: seed collections on boot

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,11 @@
   "name": "Merlin-Serski",
   "version": "1.0.0",
   "main": "bot.js",
-  "scripts": { "start": "node bot.js" },
+  "scripts": {
+    "prestart": "node seeds/seedOnBoot.js",
+    "start": "node bot.js",
+    "init:raids": "node initRaidTargets.js"
+  },
   "dependencies": {
     "axios": "^1.5.1",
     "discord.js": "^14.13.0",
@@ -10,5 +14,7 @@
     "openai": "^4.25.0",
     "pg": "^8.11.3"
   },
-  "engines": { "node": "18.16.0" }
+  "engines": {
+    "node": "18.16.0"
+  }
 }

--- a/raidUtils.js
+++ b/raidUtils.js
@@ -1,5 +1,7 @@
 const shipUtils = require('./shipUtils');
 const dbm = require('./database-manager');
+const fs = require('fs');
+const path = require('path');
 
 // Default tuning constants
 const DEFAULT_WEIGHTS = {
@@ -15,7 +17,15 @@ function randomRange(min, max) {
 }
 
 async function loadRaidTargets() {
-  return await dbm.loadCollection('raidTargets');
+  let targets = await dbm.loadCollection('raidTargets');
+  if (Object.keys(targets).length === 0) {
+    const filePath = path.join(__dirname, 'jsonStorage', 'raidTargets.json');
+    const raw = await fs.promises.readFile(filePath, 'utf8');
+    const data = JSON.parse(raw);
+    await dbm.saveCollection('raidTargets', data);
+    targets = data;
+  }
+  return targets;
 }
 
 async function loadShipCatalog() {

--- a/seeds/seedOnBoot.js
+++ b/seeds/seedOnBoot.js
@@ -1,0 +1,31 @@
+const dbm = require('../database-manager');
+const fs = require('fs');
+const path = require('path');
+
+async function run() {
+  async function seedCollectionOnce(collectionName, jsonRelPath) {
+    const existing = await dbm.loadCollection(collectionName);
+    if (Object.keys(existing).length > 0) {
+      console.log(`[seed] ${collectionName}: already present, skipping.`);
+      return;
+    }
+    const filePath = path.join(__dirname, '..', 'jsonStorage', jsonRelPath);
+    const raw = await fs.promises.readFile(filePath, 'utf8');
+    const data = JSON.parse(raw);
+    await dbm.saveCollection(collectionName, data);
+    console.log(`[seed] ${collectionName}: saved to DB.`);
+  }
+
+  const ENABLED = process.env.SEED_ON_BOOT !== 'false';
+  if (!ENABLED) {
+    console.log('[seed] Disabled via SEED_ON_BOOT=false.');
+    return;
+  }
+
+  await seedCollectionOnce('shipCatalog', 'shipCatalog.json');
+  await seedCollectionOnce('raidTargets', 'raidTargets.json');
+}
+
+run().catch(err => {
+  console.error('[seed] Failed:', err);
+});


### PR DESCRIPTION
## Summary
- seed ship catalog and raid targets automatically when bot starts
- run seeding via npm prestart hook
- add fallback loading logic for raid targets

## Testing
- `TOKEN=1 CLIENT_ID=1 GUILD_ID=1 DATABASE_URL=none node seeds/seedOnBoot.js`
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68adfd0551d4832eac1c73e6063bf761