### PR TITLE
refactor seedOnBoot helper

### DIFF
--- a/seeds/seedOnBoot.js
+++ b/seeds/seedOnBoot.js
@@ -3,12 +3,7 @@ const fs = require('fs');
 const path = require('path');
 
 async function run() {
-  async function seedCollectionOnce(collectionName, jsonRelPath) {
-    const existing = await dbm.loadCollection(collectionName);
-    if (Object.keys(existing).length > 0) {
-      console.log(`[seed] ${collectionName}: already present, skipping.`);
-      return;
-    }
+  async function seedCollection(collectionName, jsonRelPath) {
     const filePath = path.join(__dirname, '..', 'jsonStorage', jsonRelPath);
     const raw = await fs.promises.readFile(filePath, 'utf8');
     const data = JSON.parse(raw);
@@ -22,8 +17,8 @@ async function run() {
     return;
   }
 
-  await seedCollectionOnce('shipCatalog', 'shipCatalog.json');
-  await seedCollectionOnce('raidTargets', 'raidTargets.json');
+  await seedCollection('shipCatalog', 'shipCatalog.json');
+  await seedCollection('raidTargets', 'raidTargets.json');
 }
 
 run().catch(err => {


### PR DESCRIPTION
## Summary
- replace `seedCollectionOnce` with new `seedCollection` helper and remove existing data check
- always seed configured collections after verifying `SEED_ON_BOOT` is not disabled

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ae11dec3a4832eb5ad6abf06b10103