### PR TITLE
Simplify raid target loading

### DIFF
--- a/raidUtils.js
+++ b/raidUtils.js
@@ -1,7 +1,5 @@
 const shipUtils = require('./shipUtils');
 const dbm = require('./database-manager');
-const fs = require('fs');
-const path = require('path');
 
 // Default tuning constants
 const DEFAULT_WEIGHTS = {
@@ -17,15 +15,7 @@ function randomRange(min, max) {
 }
 
 async function loadRaidTargets() {
-  let targets = await dbm.loadCollection('raidTargets');
-  if (Object.keys(targets).length === 0) {
-    const filePath = path.join(__dirname, 'jsonStorage', 'raidTargets.json');
-    const raw = await fs.promises.readFile(filePath, 'utf8');
-    const data = JSON.parse(raw);
-    await dbm.saveCollection('raidTargets', data);
-    targets = data;
-  }
-  return targets;
+  return await dbm.loadCollection('raidTargets');
 }
 
 async function loadShipCatalog() {


### PR DESCRIPTION
## Summary
- simplify raid target retrieval via database manager
- remove unused `fs` and `path` imports

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ae2afcbebc832e86ced781672f2887