### PR TITLE
Seed data and optionally deploy commands before start

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "bot.js",
   "scripts": {
-    "prestart": "node seeds/seedOnBoot.js",
+    "prestart": "node seeds/seedOnBoot.js && node -e \"if(process.env.DEPLOY_COMMANDS!=='false'){require('./deploy-commands.js')}\"",
     "start": "node bot.js",
     "init:raids": "node initRaidTargets.js"
   },


### PR DESCRIPTION
## Summary
- ensure `npm start` runs seeding and optionally deploys commands before launching the bot

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ae3059ef1c832e92cb85a99514fafe