### PR TITLE
Let raid select menus bypass global interaction handler

### DIFF
--- a/interaction-handler.js
+++ b/interaction-handler.js
@@ -205,6 +205,10 @@ helpSwitch = async (interaction) => {
 }
 
 exports.handle = async (interaction) => {
+  // Ignore raid select menus; let commands/raid.js handle them
+  if (interaction.customId && interaction.customId.startsWith('raid')) {
+    return;
+  }
   console.log(interaction.customId);
   if (interaction.isModalSubmit()) {
     if (interaction.customId === 'additemmodal') {


### PR DESCRIPTION
## Summary
- Skip global handler for interactions whose customId starts with `raid`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b04336c75c832e8f175e58e2cda426