### PR TITLE
Handle raid interactions via fetched reply message

### DIFF
--- a/commands/raid.js
+++ b/commands/raid.js
@@ -31,12 +31,21 @@ module.exports = {
       .setCustomId('raidTarget')
       .setPlaceholder('Select a target')
       .addOptions(targetOptions);
-    await interaction.reply({ content: 'Choose a raid target', components: [new ActionRowBuilder().addComponents(targetMenu)], flags: 64 });
+    const replyMessage = await interaction.reply({
+      content: 'Choose a raid target',
+      components: [new ActionRowBuilder().addComponents(targetMenu)],
+      flags: 64,
+      fetchReply: true
+    });
 
     const filter = i => i.user.id === userId;
     let targetInteraction;
     try {
-      targetInteraction = await interaction.awaitMessageComponent({ filter, componentType: ComponentType.StringSelect, time: 60000 });
+      targetInteraction = await replyMessage.awaitMessageComponent({
+        filter,
+        componentType: ComponentType.StringSelect,
+        time: 60000
+      });
       await targetInteraction.deferUpdate();
     } catch (err) {
       return;
@@ -54,7 +63,7 @@ module.exports = {
       .slice(0, 25)
       .map(([name, count]) => ({ label: `${name} (${count})`, value: name }));
     if (shipOptions.length === 0) {
-      await interaction.editReply({ content: 'You have no ships to deploy.', components: [] });
+      await replyMessage.edit({ content: 'You have no ships to deploy.', components: [] });
       clientManager.clearRaidSession(userId);
       return;
     }
@@ -65,11 +74,18 @@ module.exports = {
       .setMinValues(1)
       .setMaxValues(Math.min(shipOptions.length, 25))
       .addOptions(shipOptions);
-    await interaction.editReply({ content: `Target **${targetKey}** selected. Choose ships to deploy.`, components: [new ActionRowBuilder().addComponents(shipMenu)] });
+    await replyMessage.edit({
+      content: `Target **${targetKey}** selected. Choose ships to deploy.`,
+      components: [new ActionRowBuilder().addComponents(shipMenu)]
+    });
 
     let shipInteraction;
     try {
-      shipInteraction = await interaction.awaitMessageComponent({ filter, componentType: ComponentType.StringSelect, time: 60000 });
+      shipInteraction = await replyMessage.awaitMessageComponent({
+        filter,
+        componentType: ComponentType.StringSelect,
+        time: 60000
+      });
       await shipInteraction.deferUpdate();
     } catch (err) {
       clientManager.clearRaidSession(userId);
@@ -77,7 +93,10 @@ module.exports = {
     }
 
     const selectedShips = shipInteraction.values;
-    await interaction.editReply({ content: `Enter quantities for each ship in the format "Ship:Amount" separated by commas.`, components: [] });
+    await replyMessage.edit({
+      content: 'Enter quantities for each ship in the format "Ship:Amount" separated by commas.',
+      components: []
+    });
 
     const msgFilter = m => m.author.id === userId;
     const collected = await interaction.channel.awaitMessages({ filter: msgFilter, max: 1, time: 60000 });


### PR DESCRIPTION
## Summary
- Fetch and store initial raid reply to await select menu interactions
- Switch subsequent component waits and edits to use the fetched message

## Testing
- `node --check commands/raid.js`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b08451fd44832e94db5522a2804d64