### PR TITLE
Defer inventory command reply to avoid Discord timeout

### DIFF
--- a/commands/shopCommands/inventory.js
+++ b/commands/shopCommands/inventory.js
@@ -2,12 +2,15 @@ const { SlashCommandBuilder } = require('discord.js');
 const shop = require('../../shop'); // Importing the database manager
 
 module.exports = {
-	data: new SlashCommandBuilder()
-		.setName('inventory')
-		.setDescription('Show your inventory'),
-	async execute(interaction) {
-        const userID = interaction.user.id;
-		var replyEmbed = await shop.createInventoryEmbed(userID);
-		await interaction.reply(({ embeds: [replyEmbed] }));
-	},
+        data: new SlashCommandBuilder()
+                .setName('inventory')
+                .setDescription('Displays your inventory'),
+        async execute(interaction) {
+                const userID = interaction.user.id;
+                // Immediately defer the reply so Discord doesn’t time out
+                await interaction.deferReply({ flags: 64 }); // 64 = Ephemeral
+                const inventoryEmbed = await shop.createInventoryEmbed(userID);
+                // Edit the deferred reply with the embed
+                await interaction.editReply({ embeds: [inventoryEmbed] });
+        },
 };


### PR DESCRIPTION
## Summary
- defer /inventory command reply immediately and edit it with the inventory embed to avoid "Unknown interaction" errors

## Testing
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68b0a0e6a744832ea496649e367b29e7