### PR TITLE
Update raid loot tables with credits

### DIFF
--- a/jsonStorage/raidTargets.json
+++ b/jsonStorage/raidTargets.json
@@ -1,6 +1,7 @@
 {
   "easy": {
     "loot": {
+      "credits": [200, 400],
       "AFM": [5, 10],
       "PCC": [2, 5]
     },
@@ -9,25 +10,28 @@
   },
   "medium": {
     "loot": {
+      "credits": [500, 800],
       "AFM": [10, 20],
       "PCC": [5, 10],
       "OOP": [1, 3]
     },
-    "enemyPower": 300,
+    "enemyPower": 400,
     "lossFactor": 0.7
   },
   "hard": {
     "loot": {
+      "credits": [1000, 1500],
       "AFM": [20, 40],
       "PCC": [10, 20],
       "OOP": [5, 8],
       "GGP": [2, 4]
     },
-    "enemyPower": 800,
+    "enemyPower": 1000,
     "lossFactor": 0.9
   },
   "extreme": {
     "loot": {
+      "credits": [2000, 3000],
       "AFM": [40, 60],
       "PCC": [20, 40],
       "OOP": [10, 15],
@@ -35,8 +39,7 @@
       "QFR": [1, 2],
       "NCM": [1, 1]
     },
-    "enemyPower": 1500,
+    "enemyPower": 2500,
     "lossFactor": 1.0
   }
 }
-


### PR DESCRIPTION
## Summary
- expand raid target loot tables across difficulties with credits and updated enemy power

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b23360bb24832e9dc88474c20997d3