### PR TITLE
feat: add rare raid drop constants

### DIFF
--- a/raidUtils.js
+++ b/raidUtils.js
@@ -10,6 +10,20 @@ const DEFAULT_WEIGHTS = {
   tier: 5,
 };
 
+// Chance (0–1) to drop a rare ship on a win/pyrrhic win
+const RARE_DROP_CHANCE = {
+  medium: 0.05,
+  hard: 0.05,
+  extreme: 0.05,
+};
+
+// Mapping from tier to the ship type awarded on a rare drop
+const RARE_DROP_SHIP = {
+  medium: 'Corvette',
+  hard: 'Destroyer',
+  extreme: 'Cruiser',
+};
+
 function randomRange(min, max) {
   return Math.random() * (max - min) + min;
 }
@@ -111,4 +125,6 @@ module.exports = {
   calculateFleetPowerWeighted,
   simulateBattle,
   DEFAULT_WEIGHTS,
+  RARE_DROP_CHANCE,
+  RARE_DROP_SHIP,
 };


### PR DESCRIPTION
## Summary
- add configurable rare ship drop chance and mapping
- export rare drop constants for cross-module access

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b303f65b54832eb1cf08689cc0ae11