### PR TITLE
fix: align simulateBattle call and skip ship rewards

### DIFF
--- a/commands/raid.js
+++ b/commands/raid.js
@@ -153,10 +153,10 @@ module.exports = {
     const sim = await raidUtils.simulateBattle(
       fleetSelection,
       targets[targetKey],
-      targetKey,
-      charData,
       weights,
-      variance
+      variance,
+      targetKey,
+      charData
     );
 
     // Remove casualties from fleet and inventory separately without merging them
@@ -180,12 +180,8 @@ module.exports = {
       for (const [res, amt] of Object.entries(sim.loot)) {
         if (res === 'credits' || res === 'gold') {
           charData.balance = (charData.balance || 0) + amt;
-        } else {
+        } else if (!catalog[res]) {
           if (!charData.inventory) charData.inventory = {};
-          if (res === raidUtils.RARE_DROP_SHIP[targetKey]) {
-            // Rare ship already added in simulateBattle
-            continue;
-          }
           charData.inventory[res] = (charData.inventory[res] || 0) + amt;
         }
       }

--- a/raidUtils.js
+++ b/raidUtils.js
@@ -67,10 +67,10 @@ async function calculateFleetPowerWeighted(fleet = {}, weights = DEFAULT_WEIGHTS
 async function simulateBattle(
   fleet,
   target,
-  tier,
-  charData,
   weights = DEFAULT_WEIGHTS,
-  variance = 0.1
+  variance = 0.1,
+  tier,
+  charData
 ) {
   const basePlayerPower = await calculateFleetPowerWeighted(fleet, weights);
   const playerRoll = rollPower(basePlayerPower, variance);


### PR DESCRIPTION
## Summary
- pass weights and variance before tier and char data when simulating raids
- ignore ship-type loot when applying raid rewards to avoid duplicate rare drops
- reorder simulateBattle parameters to match new call signature

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b3078f7068832e8c366dda0ffcdd7f