### PR TITLE
fix: defer edit item menu

### DIFF
--- a/commands/shopCommands/edititemmenu.js
+++ b/commands/shopCommands/edititemmenu.js
@@ -2,28 +2,27 @@ const { SlashCommandBuilder } = require('discord.js');
 const shop = require('../../shop'); // Importing the database manager
 
 module.exports = {
-	data: new SlashCommandBuilder()
-		.setName('edititemmenu')
-		.setDescription('Show the edit item menu')
-		.setDefaultMemberPermissions(0)
-		.addStringOption((option) =>
-		option.setName('itemname')
-			.setDescription('The item name')
-			.setRequired(true)
-		),
-	execute(interaction) {
-		const itemName = interaction.options.getString('itemname');
+    data: new SlashCommandBuilder()
+        .setName('edititemmenu')
+        .setDescription('Show the edit item menu')
+        .setDefaultMemberPermissions(0)
+        .addStringOption((option) =>
+            option.setName('itemname')
+                .setDescription('The item name')
+                .setRequired(true)
+        ),
+    async execute(interaction) {
+        const itemName = interaction.options.getString('itemname');
+        await interaction.deferReply();
 
-		(async () => {
-			//shop.editItemMenu returns an array with the first element being the replyEmbed and the second element being the rows
-			let reply = await shop.editItemMenu(itemName, 1, interaction.user.tag);
-            if (typeof(reply) == 'string') {
-                await interaction.reply(reply);
-            } else {
-				let replyEmbed = reply[0];
-				let rows = reply[1];
-                await interaction.reply({ embeds: [replyEmbed], components: [rows]});
-            }
-		})()
-	},
+        // shop.editItemMenu returns an array with the first element being the replyEmbed and the second element being the rows
+        const reply = await shop.editItemMenu(itemName, 1, interaction.user.tag);
+        if (typeof reply === 'string') {
+            await interaction.editReply(reply);
+        } else {
+            const [replyEmbed, rows] = reply;
+            await interaction.editReply({ embeds: [replyEmbed], components: [rows] });
+        }
+    },
 };
+


### PR DESCRIPTION
## Summary
- make `edititemmenu` handler async and defer reply
- await shop.editItemMenu and respond with editReply

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b4be066740832ea9d8edb36339b0f9