### PR TITLE
use saveFile for editing item metadata

### DIFF
--- a/shop.js
+++ b/shop.js
@@ -972,11 +972,14 @@ class shop {
 
     //Load user data, check if user has attribute "Item Edited" and if so change the value to the item name. If not, create the attribute
     let userData = await dbm.loadCollection('characters');
+    if (!userData[tag]) {
+      userData[tag] = {};
+    }
     if (!userData[tag].editingFields) {
       userData[tag].editingFields = {};
     }
     userData[tag].editingFields["Item Edited"] = itemName;
-    await dbm.saveCollection('characters', userData);
+    await dbm.saveFile('characters', tag, userData[tag]);
 
     //Loatd item data
     let itemData = shopData[itemName];


### PR DESCRIPTION
## Summary
- ensure `editItemMenu` initializes user data and uses `saveFile`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b4cf0e418c832eaf894a52fbc941d8