### PR TITLE
Handle missing income data defaults

### DIFF
--- a/admin.js
+++ b/admin.js
@@ -1012,11 +1012,11 @@ When selected grants the:
 
   static async allIncomes(page = 1) {
     let maxLength = 10;
-    let incomeList = await dbm.loadFile("keys", "incomeList");
-    let shopData = await dbm.loadCollection("shop");
-    if (Object.keys(incomeList).length == 0) {
+    let incomeList = await dbm.loadFile("keys", "incomeList") || {};
+    if (Object.keys(incomeList).length === 0) {
       return "No incomes found";
     }
+    let shopData = await dbm.loadCollection("shop");
 
     let goldList = [];
     let itemList = [];
@@ -1045,12 +1045,9 @@ When selected grants the:
     //Combine all lists into one list
     for (const income of sortedIncomes) {
       let incomeValue = incomeList[income];
-      let emoji = incomeValue.emoji;
-      let delay = incomeValue.delay;
-      if (delay == undefined || delay == "") {
-        delay = "1D";
-      }
-      let roles = incomeValue.roles;
+      let emoji = incomeValue.emoji || "";
+      let delay = incomeValue.delay || "1D";
+      let roles = Array.isArray(incomeValue.roles) ? incomeValue.roles : [];
       let rolesString = "";
 
       let justGold = false;


### PR DESCRIPTION
## Summary
- Safeguard allIncomes by defaulting empty incomeList and early return when no incomes exist
- Apply default values for emoji, delay, and roles in income entries

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b4cfeee86c832e9dbf6229746f0472