### PR TITLE
Replace STATBOOST stats with HP/STR/DEX/INT/CHA

### DIFF
--- a/char.js
+++ b/char.js
@@ -1218,9 +1218,11 @@ class char {
             return "This item does not have a countdown. Likely an error in setup, ping Alex or Serski";
           }
 
-          const PrestigeEmoji = '<:Prestige:1165722839228354610>';
-          const MartialEmoji = '<:Martial:1165722873248354425>';
-          const IntrigueEmoji = '<:Intrigue:1165722896522563715>';
+          const hpEmoji = clientManager.getEmoji("HP");
+          const strEmoji = clientManager.getEmoji("STR");
+          const dexEmoji = clientManager.getEmoji("DEX");
+          const intEmoji = clientManager.getEmoji("INT");
+          const chaEmoji = clientManager.getEmoji("CHA");
 
           if (shopData[itemName].usageCase.gives) {
             let takeString = "";
@@ -1238,14 +1240,20 @@ class char {
                 let val = shopData[itemName].usageCase.takes[key];
                 let icon;
                 switch (key) {
-                  case "Prestige":
-                    icon = PrestigeEmoji;
+                  case "HP":
+                    icon = hpEmoji;
                     break;
-                  case "Martial":
-                    icon = MartialEmoji;
+                  case "STR":
+                    icon = strEmoji;
                     break;
-                  case "Intrigue":
-                    icon = IntrigueEmoji;
+                  case "DEX":
+                    icon = dexEmoji;
+                    break;
+                  case "INT":
+                    icon = intEmoji;
+                    break;
+                  case "CHA":
+                    icon = chaEmoji;
                     break;
                   default:
                     return "This use case includes an invalid stat name. Likely an error in setup, contact Alex or Serski";
@@ -1262,14 +1270,20 @@ class char {
               let val = shopData[itemName].usageCase.gives[key];
               let icon;
               switch (key) {
-                case "Prestige":
-                  icon = PrestigeEmoji;
+                case "HP":
+                  icon = hpEmoji;
                   break;
-                case "Martial":
-                  icon = MartialEmoji;
+                case "STR":
+                  icon = strEmoji;
                   break;
-                case "Intrigue":
-                  icon = IntrigueEmoji;
+                case "DEX":
+                  icon = dexEmoji;
+                  break;
+                case "INT":
+                  icon = intEmoji;
+                  break;
+                case "CHA":
+                  icon = chaEmoji;
                   break;
                 default:
                   return "This use case includes an invalid stat name. Likely an error in setup, contact Alex or Serski";


### PR DESCRIPTION
## Summary
- Replace hard-coded Prestige/Martial/Intrigue stats in STATBOOST items with new HP/STR/DEX/INT/CHA set
- Switch statements updated to map new stat names to their corresponding emojis via `clientManager.getEmoji`

## Testing
- `node --check char.js`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b4d7aec5dc832e9158cac09132c729