### PR TITLE
Restrict /changeplayerstats to core stats

### DIFF
--- a/commands/charCommands/changeplayerstats.js
+++ b/commands/charCommands/changeplayerstats.js
@@ -4,9 +4,15 @@ const char = require('../../char'); // Importing the database manager
 module.exports = {
     data: new SlashCommandBuilder()
         .setName('changeplayerstats')
-        .setDescription('Change stats of a player')
+        .setDescription('Change HP, STR, DEX, INT, or CHA of a player')
         .addUserOption(option => option.setName('player').setDescription('The player to set the gold of').setRequired(true))
-        .addStringOption(option => option.setName('stat').setDescription('The stat to change').setRequired(true))
+        .addStringOption(option => option.setName('stat').setDescription('Which stat to change (HP, STR, DEX, INT, CHA)').setRequired(true)
+            .addChoices(
+                {name: 'HP', value: 'HP'},
+                {name: 'STR', value: 'STR'},
+                {name: 'DEX', value: 'DEX'},
+                {name: 'INT', value: 'INT'},
+                {name: 'CHA', value: 'CHA'}))
         .addIntegerOption(option => option.setName('value').setDescription('The value to change stat by').setRequired(true))
         .setDefaultMemberPermissions(0),
     async execute(interaction) {


### PR DESCRIPTION
## Summary
- limit `/changeplayerstats` stat option to HP, STR, DEX, INT, or CHA
- clarify command description and help text

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b4d9ebf888832eb7192b6b253e8e8f