### PR TITLE
feat: add script to migrate stat keys

### DIFF
--- a/scripts/migrateStatKeys.js
+++ b/scripts/migrateStatKeys.js
@@ -1,0 +1,33 @@
+const dbm = require('../database-manager');
+
+const KEY_MAP = {
+  'Change Legitimacy (#)': 'Change HP (#)',
+  'Change Strength (#)': 'Change STR (#)',
+  'Change Dexterity (#)': 'Change DEX (#)',
+  'Change Intelligence (#)': 'Change INT (#)',
+  'Change Charisma (#)': 'Change CHA (#)'
+};
+
+async function migrateStatKeys() {
+  const shopData = await dbm.loadCollection('shop');
+  let changes = 0;
+
+  for (const [itemName, itemData] of Object.entries(shopData)) {
+    if (!itemData || !itemData.usageOptions) continue;
+
+    for (const [oldKey, newKey] of Object.entries(KEY_MAP)) {
+      if (Object.prototype.hasOwnProperty.call(itemData.usageOptions, oldKey)) {
+        itemData.usageOptions[newKey] = itemData.usageOptions[oldKey];
+        delete itemData.usageOptions[oldKey];
+        changes++;
+      }
+    }
+  }
+
+  await dbm.saveCollection('shop', shopData);
+  console.log(`Migration complete. Updated ${changes} fields.`);
+}
+
+migrateStatKeys().catch((err) => {
+  console.error('Migration failed:', err);
+});


### PR DESCRIPTION
## Summary
- add `scripts/migrateStatKeys.js` to rename legacy stat keys in the `shop` collection

## Testing
- `TOKEN=1 CLIENT_ID=1 GUILD_ID=1 DATABASE_URL=postgres://localhost node scripts/migrateStatKeys.js`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b4db88fc40832eb385f96fb4c0aacc