### PR TITLE
Use deferred reply for sales command

### DIFF
--- a/commands/salesCommands/sales.js
+++ b/commands/salesCommands/sales.js
@@ -6,7 +6,9 @@ module.exports = {
         .setName('sales')
         .setDescription('List sales'),
     async execute(interaction) {
-        let [embed, rows] = await marketplace.createSalesEmbed(1, interaction);
-        await interaction.reply({ embeds: [embed], components: rows});
+        await interaction.deferReply({ ephemeral: true });
+        const [embed, rows] = await marketplace.createSalesEmbed(1, interaction);
+        await interaction.editReply({ embeds: [embed], components: rows });
     },
 };
+


### PR DESCRIPTION
## Summary
- Convert `sales` command to use deferred replies
- Send sales embed via `interaction.editReply`

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b58d9830d4832e9a00ff5885ea5d41