### PR TITLE
Make /incomes response ephemeral

### DIFF
--- a/commands/charCommands/incomes.js
+++ b/commands/charCommands/incomes.js
@@ -5,13 +5,16 @@ module.exports = {
 	data: new SlashCommandBuilder()
 		.setName('incomes')
 		.setDescription('Collect your daily incomes'),
-	async execute(interaction) {
-        const userID = interaction.user.tag;
-		const numericID = interaction.user.id;
-		var [replyEmbed, replyString] = await char.incomes(userID, numericID);
-		await interaction.reply(({ embeds: [replyEmbed] }));
-		if (replyString) {
-			interaction.channel.send(replyString);
-		}
-	},
+        async execute(interaction) {
+                const userID = interaction.user.tag;
+                const numericID = interaction.user.id;
+
+                await interaction.deferReply({ ephemeral: true });
+
+                const [replyEmbed, replyString] = await char.incomes(userID, numericID);
+                await interaction.editReply({ embeds: [replyEmbed] });
+                if (replyString) {
+                        await interaction.followUp({ content: replyString, ephemeral: true });
+                }
+        },
 };


### PR DESCRIPTION
## Summary
- Make `/incomes` command defer and edit an ephemeral reply
- Send any extra income message as a private follow-up

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b593fb6ca4832eab0082e388d01e83