### PR TITLE
Pass user roles to incomes

### DIFF
--- a/commands/charCommands/incomes.js
+++ b/commands/charCommands/incomes.js
@@ -8,10 +8,11 @@ module.exports = {
         async execute(interaction) {
                 const userID = interaction.user.tag;
                 const numericID = interaction.user.id;
+                const roles = interaction.member.roles.cache;
 
                 await interaction.deferReply({ ephemeral: true });
 
-                const [replyEmbed, replyString] = await char.incomes(userID, numericID);
+                const [replyEmbed, replyString] = await char.incomes(userID, numericID, roles);
                 await interaction.editReply({ embeds: [replyEmbed] });
                 if (replyString) {
                         await interaction.followUp({ content: replyString, ephemeral: true });


### PR DESCRIPTION
## Summary
- Capture interaction roles in `/incomes` command
- Forward roles to `char.incomes` for processing

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b60871d6f0832e88781330ae2ee06b