### PR TITLE
cache income list

### DIFF
--- a/char.js
+++ b/char.js
@@ -6,6 +6,7 @@ const { ActionRowBuilder, ButtonBuilder, ButtonStyle, EmbedBuilder, createWebhoo
 const shipUtils = require('./shipUtils');
 
 class char {
+  static incomeListCache = null;
   static async warn(playerID) {
     console.log(playerID);
     let collectionName = 'characters';
@@ -348,7 +349,10 @@ class char {
 
     // Load the data
     let charData = await dbm.loadFile(collectionName, userID);
-    let incomeListFromRoles = await dbm.loadFile('keys', 'incomeList');
+    if (char.incomeListCache === null) {
+      char.incomeListCache = await dbm.loadFile('keys', 'incomeList');
+    }
+    let incomeListFromRoles = char.incomeListCache;
 
     var now = new Date();
 


### PR DESCRIPTION
## Summary
- add static `incomeListCache` to `char` class
- reuse cached income list in `incomes`

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b609bd04cc832e8527e71e8aabdabb