### PR TITLE
Ensure inspect shop command replies are ephemeral

### DIFF
--- a/commands/shopCommands/inspect.js
+++ b/commands/shopCommands/inspect.js
@@ -18,8 +18,8 @@ module.exports = {
             if (typeof(replyEmbed) == 'string') {
                 await interaction.reply({content: replyEmbed, ephemeral: true });
             } else {
-                await interaction.reply({ embeds: [replyEmbed] });
+                await interaction.reply({ embeds: [replyEmbed], ephemeral: true });
             }
-		})()
-	},
+                })()
+        },
 };


### PR DESCRIPTION
## Summary
- Make inspect command embed responses ephemeral so results are visible only to the user

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b6c9e3c440832ea88b8555d4e8609d