### PR TITLE
feat: make stats command responses ephemeral

### DIFF
--- a/commands/charCommands/stats.js
+++ b/commands/charCommands/stats.js
@@ -11,10 +11,10 @@ module.exports = {
 		(async () => {
             let replyEmbed = await char.stats(charID);
             if (typeof(replyEmbed) == 'string') {
-                await interaction.reply(replyEmbed);
+                await interaction.reply({ content: replyEmbed, ephemeral: true });
             } else {
-                await interaction.reply({ embeds: [replyEmbed] });
+                await interaction.reply({ embeds: [replyEmbed], ephemeral: true });
             }
-		})()
-	},
+                })()
+        },
 };


### PR DESCRIPTION
## Summary
- make `/stats` reply only visible to the invoker

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b6f3831d30832e8985df108bab5827