### PR TITLE
Use numeric Discord IDs for character storage

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -93,28 +93,15 @@ client.on(Events.InteractionCreate, async interaction => {
 });
 
 client.on('guildMemberAdd', member => {
-    // Assuming 'newchar' is a function you've defined to handle the new character creation
-	let memberID = member.id;
-	let memberName = member.user.tag;
-	let memberBio = "A new member of Britannia!";
-	char.newChar(memberName, memberName, memberBio, memberID);
+    let memberID = member.id;
+    let memberName = member.user.tag;
+    let memberBio = "A new member of Britannia!";
+    char.newChar(memberID, memberName, memberBio);
 });
 
 client.on('guildMemberRemove', member => {
-	let memberID = member.id;
-        if (process.env.DEBUG) console.log("Member ID: " + memberID);
-});
-
-client.on('userUpdate', (oldMember, newMember) => {
-	// Since data in Characters is stored by tag, we need to update the username in the database when a user changes their username
-	let oldName = oldMember.tag;
-	let newName = newMember.tag;
-
-	oldData = dbm.loadFile('characters', oldName);
-	if (oldData) {
-		dbm.saveFile('characters', newName, oldData);
-		dbm.docDelete('characters', oldName);
-	}
+    let memberID = member.id;
+    if (process.env.DEBUG) console.log("Member ID: " + memberID);
 });
 
 //For commands that need to be run daily, and daily logging of infos and such

--- a/char.js
+++ b/char.js
@@ -7,25 +7,25 @@ const shipUtils = require('./shipUtils');
 
 class char {
   static incomeListCache = null;
-  static async warn(playerID) {
-    if (process.env.DEBUG) console.log(playerID);
+  static async warn(numericID) {
+    if (process.env.DEBUG) console.log(numericID);
     let collectionName = 'characters';
-    let charData = await dbm.loadFile(collectionName, playerID);
+    let charData = await dbm.loadFile(collectionName, String(numericID));
     if (charData) {
       if (!charData.warns) {
         charData.warns = 0;
       }
       charData.warns++;
-      await dbm.saveFile(collectionName, playerID, charData);
+      await dbm.saveFile(collectionName, String(numericID), charData);
       return "Player has been warned. They now have " + charData.warns + " warnings.";
     } else {
       return "Player not found";
     }
   }
 
-  static async checkWarns(playerID) {
+  static async checkWarns(numericID) {
     let collectionName = 'characters';
-    let charData = await dbm.loadFile(collectionName, playerID);
+    let charData = await dbm.loadFile(collectionName, String(numericID));
     if (charData) {
       if (!charData.warns) {
         charData.warns = 0;
@@ -37,12 +37,12 @@ class char {
   }
 
   // Function to add items
-  static async newChar(playerID, charName, charBio, numericID) {
+  static async newChar(numericID, charName, charBio) {
     // Set the collection name
     let collectionName = 'characters';
 
     // Load the player's character data (if it exists)
-    let charData = await dbm.loadFile(collectionName, playerID);
+    let charData = await dbm.loadFile(collectionName, String(numericID));
 
     if (charData) {
       // If the character already exists, update the fields
@@ -71,35 +71,35 @@ class char {
     }
 
     // Save the character data
-    await dbm.saveFile(collectionName, playerID, charData);
+    await dbm.saveFile(collectionName, String(numericID), charData);
   }
 
   //returns player name and bio from playerID
-  static async editCharPlaceholders(playerID) {
+  static async editCharPlaceholders(numericID) {
     let collectionName = 'characters';
-    let charData = await dbm.loadFile(collectionName, playerID);
+    let charData = await dbm.loadFile(collectionName, String(numericID));
     if (charData) {
       return [charData.name, charData.bio];
     } else {
       return "ERROR";
     }
-  }  
+  }
 
   //Setavatar using new saveFile and loadFile
-  static async setAvatar(avatarURL, userID) {
+  static async setAvatar(avatarURL, numericID) {
     try {
       // Make a HEAD request to check if the URL leads to a valid image
       const response = await axios.head(avatarURL, { maxRedirects: 5 });
-  
+
       // Check if the response status code indicates success (e.g., 200)
       if (response.status === 200) {
         let collectionName = 'characters';
-        let charData = await dbm.loadFile(collectionName, userID);
-  
+        let charData = await dbm.loadFile(collectionName, String(numericID));
+
         charData.icon = avatarURL;
-  
-        await dbm.saveFile(collectionName, userID, charData);
-  
+
+        await dbm.saveFile(collectionName, String(numericID), charData);
+
         return "Avatar has been set";
       } else {
         return "Error: Avatar URL is not valid (HTTP status code " + response.status + ").";
@@ -110,9 +110,9 @@ class char {
   }
 
   //New commands using saveFile, saveCollection, loadFile and loadCollection
-  static async balance(userID) {
+  static async balance(numericID) {
     let collectionName = 'characters';
-    let charData = await dbm.loadFile(collectionName, userID);
+    let charData = await dbm.loadFile(collectionName, String(numericID));
     if (charData) {
       const charEmbed = {
         color: 0x36393e,
@@ -128,11 +128,11 @@ class char {
     }
   }
 
-  static async stats(userID) {
+  static async stats(numericID) {
     let collectionName = 'characters';
     let charData;
     try {
-      charData = await dbm.loadFile(collectionName, userID);
+      charData = await dbm.loadFile(collectionName, String(numericID));
     } catch (error) {
       console.error(error);
       return "Character not found- use /newchar first";
@@ -144,7 +144,7 @@ class char {
           name: charData.name,
           icon_url: charData.icon ? charData.icon : 'https://cdn.discordapp.com/attachments/1393917452731289680/1411714755042869268/AEGIR_SMALL_copy.png?ex=68b5a951&is=68b457d1&hm=36aea50e9270da5b5b7d65cf9364ce946e1a05ebc2aa0ed44bf76e80470673f2',
         },
-        description: await this.getStatsBlock(charData, userID),
+        description: await this.getStatsBlock(charData, String(numericID)),
       };
 
       return charEmbed;
@@ -197,9 +197,9 @@ class char {
     return [balanceEmbed, rows];
   }
 
-  static async me(userID) {
+  static async me(numericID) {
     let collectionName = 'characters';
-    let charData = await dbm.loadFile(collectionName, userID);
+    let charData = await dbm.loadFile(collectionName, String(numericID));
     if (charData) {
       let bioString = charData.bio;
 
@@ -214,9 +214,9 @@ class char {
     }
   }
 
-  static async fleetPower(userID) {
+  static async fleetPower(numericID) {
     const collectionName = 'characters';
-    const charData = await dbm.loadFile(collectionName, userID);
+    const charData = await dbm.loadFile(collectionName, String(numericID));
     if (!charData) {
       return "You haven't made a character! Use /newchar first";
     }
@@ -232,9 +232,9 @@ class char {
     return stats;
   }
 
-  static async char(userID) {
+  static async char(numericID) {
     let collectionName = 'characters';
-    let charData = await dbm.loadFile(collectionName, userID);
+    let charData = await dbm.loadFile(collectionName, String(numericID));
     if (charData) {
       let bioString = charData.bio;
 
@@ -249,7 +249,7 @@ class char {
         fields: [
           {
             name: clientManager.getEmoji("Gold") + " Balance: " + (charData.balance ? charData.balance : 0),
-            value: await this.getStatsBlock(charData, userID),
+            value: await this.getStatsBlock(charData, String(numericID)),
           },
         ],
       };
@@ -259,7 +259,7 @@ class char {
     }
   }
 
-  static async getStatsBlock(charData, userID) {
+  static async getStatsBlock(charData, numericID) {
     const strEmoji = clientManager.getEmoji("STR");
     const dexEmoji = clientManager.getEmoji("DEX");
     const intEmoji = clientManager.getEmoji("INT");
@@ -302,8 +302,8 @@ class char {
       charData.stats.INT = int;
       charData.stats.CHA = cha;
       charData.stats.HP = hp;
-      if (process.env.DEBUG) console.log(userID);
-      await dbm.saveFile('characters', userID, charData);
+      if (process.env.DEBUG) console.log(numericID);
+      await dbm.saveFile('characters', String(numericID), charData);
     }
 
     return "**`━━━━━━━Stats━━━━━━━`**\n"+
@@ -315,8 +315,8 @@ class char {
             "**`━━━━━━━━━━━━━━━━━━━`**";
   }
 
-  static async say(userID, message, channelID) {
-    let charData = await dbm.loadFile('characters', userID);
+  static async say(numericID, message, channelID) {
+    let charData = await dbm.loadFile('characters', String(numericID));
     if (charData) {
       let webhookName = charData.name;
       //if charData.icon is undefined, set it to the default avatar
@@ -344,11 +344,11 @@ class char {
     }
   }
 
-  static async incomes(userID, numericID, roles = null) {
+  static async incomes(numericID, roles = null) {
     let collectionName = 'characters';
 
     // Load the data
-    let charData = await dbm.loadFile(collectionName, userID);
+    let charData = await dbm.loadFile(collectionName, String(numericID));
     if (char.incomeListCache === null) {
       char.incomeListCache = await dbm.loadFile('keys', 'incomeList');
     }
@@ -500,7 +500,7 @@ class char {
         charData[key] = false;
       }
       charData.incomeAvailable = false;
-      await dbm.saveFile(collectionName, userID, charData);
+      await dbm.saveFile(collectionName, String(numericID), charData);
     }
     
     const incomeEmbed = {
@@ -508,7 +508,7 @@ class char {
       title: "**__Incomes__**",
       description: `<@${numericID}>\n\n${superstring}`,
     };
-  
+
     return [incomeEmbed, afterString];
   }
 
@@ -596,7 +596,7 @@ class char {
 
     let returnEmbed = new EmbedBuilder();
     const charactersCollection = 'characters';
-    let charData = await dbm.loadFile(charactersCollection, charID);
+    let charData = await dbm.loadFile(charactersCollection, String(charID));
     const shopCollection = 'shop';
     let itemData = await dbm.loadFile(shopCollection, itemName);
 
@@ -782,7 +782,7 @@ class char {
       returnEmbed.addFields({ name: '**Items:**', value: itemString });
     }
 
-    await dbm.saveFile(charactersCollection, charID, charData);
+    await dbm.saveFile(charactersCollection, String(charID), charData);
 
       //If theres an error, give 
     if (takeRoles) {
@@ -1062,7 +1062,7 @@ class char {
 
     let returnEmbed = new EmbedBuilder();
     const charactersCollection = 'characters';
-    let charData = await dbm.loadFile(charactersCollection, charID);
+    let charData = await dbm.loadFile(charactersCollection, String(charID));
     const shopCollection = 'shop';
     let shopData = await dbm.loadCollection(shopCollection);
 
@@ -1121,7 +1121,7 @@ class char {
         return "Item does not have a crafting time. Likely an error in setup, ping Alex or Serski";
       }
     }
-    dbm.saveFile(charactersCollection, charID, charData);
+    dbm.saveFile(charactersCollection, String(charID), charData);
     return returnEmbed;
   }
 
@@ -1129,7 +1129,7 @@ class char {
   static async craftingCooldowns(charID) {
     let returnEmbed = new EmbedBuilder();
     const charactersCollection = 'characters';
-    let charData = await dbm.loadFile(charactersCollection, charID);
+    let charData = await dbm.loadFile(charactersCollection, String(charID));
     const shopCollection = 'shop';
     let shopData = await dbm.loadCollection(shopCollection);
     let finishedCrafts = [];
@@ -1180,7 +1180,7 @@ class char {
 
         delete charData.cooldowns.craftSlots[finishedSlotKeys[i]];
 
-        await dbm.saveFile(charactersCollection, charID, charData);
+        await dbm.saveFile(charactersCollection, String(charID), charData);
       }
     }
 
@@ -1200,7 +1200,7 @@ class char {
 
     let returnEmbed = new EmbedBuilder();
     const charactersCollection = 'characters';
-    let charData = await dbm.loadFile(charactersCollection, charID);
+    let charData = await dbm.loadFile(charactersCollection, String(charID));
     const shopCollection = 'shop';
     let shopData = await dbm.loadCollection(shopCollection);
 
@@ -1396,7 +1396,7 @@ class char {
         { name: '**Can be used again:**', value: '<t:' + charData.cooldowns[itemName] + ':R>'}
       );
     }
-    dbm.saveFile(charactersCollection, charID, charData);
+    dbm.saveFile(charactersCollection, String(charID), charData);
     return returnEmbed;
   }*/
 
@@ -1409,7 +1409,7 @@ class char {
     }
     if (charData) {
       charData.balance += gold;
-      await dbm.saveFile(collectionName, player, charData);
+      await dbm.saveFile(collectionName, String(player), charData);
       return true;
     } else {
       return false;
@@ -1425,7 +1425,7 @@ class char {
     }
     if (charData) {
       charData.balance = gold;
-      await dbm.saveFile(collectionName, player, charData);
+      await dbm.saveFile(collectionName, String(player), charData);
       return true;
     } else {
       return false;
@@ -1460,7 +1460,7 @@ class char {
       if (charData.stats[stat] > 100) {
         charData.stats[stat] = 100;
       }
-      await dbm.saveFile(collectionName, player, charData);
+      await dbm.saveFile(collectionName, String(player), charData);
       return stat;
     }
   }
@@ -1496,7 +1496,7 @@ class char {
           charData.inventory[item] = 0;
         }
       }
-      await dbm.saveFile(collectionName, player, charData);
+      await dbm.saveFile(collectionName, String(player), charData);
       return true;
     } else {
       return false;
@@ -1574,7 +1574,7 @@ class char {
           charData.storage[item] = amount;
         }
         charData.inventory[item] -= amount;
-        await dbm.saveFile(collectionName, player, charData);
+        await dbm.saveFile(collectionName, String(player), charData);
         return true;
       } else {
         return "You don't have enough of that item!";
@@ -1612,7 +1612,7 @@ class char {
           charData.inventory[item] = amount;
         }
         charData.storage[item] -= amount;
-        await dbm.saveFile(collectionName, player, charData);
+        await dbm.saveFile(collectionName, String(player), charData);
         return true;
       } else {
         return "You don't have enough of that item!";
@@ -1634,7 +1634,7 @@ class char {
       if (charData.balance >= gold) {
         charData.balance -= gold;
         charData.bank += gold;
-        await dbm.saveFile(collectionName, player, charData);
+        await dbm.saveFile(collectionName, String(player), charData);
         return true;
       } else {
         return "You don't have enough gold!";
@@ -1656,7 +1656,7 @@ class char {
       if (charData.bank >= gold) {
         charData.balance += gold;
         charData.bank -= gold;
-        await dbm.saveFile(collectionName, player, charData);
+        await dbm.saveFile(collectionName, String(player), charData);
         return true;
       } else {
         return "You don't have enough gold!";
@@ -1664,9 +1664,9 @@ class char {
     }
   }
 
-  static async bank(userID) {
+  static async bank(numericID) {
     let collectionName = 'characters';
-    let charData = await dbm.loadFile(collectionName, userID);
+    let charData = await dbm.loadFile(collectionName, String(numericID));
     if (charData) {
       if (!charData.bank) {
         charData.bank = 0;
@@ -1731,8 +1731,8 @@ class char {
         } else {
           charData2.inventory[item] = amount;
         }
-        await dbm.saveFile(collectionName, playerGiving, charData);
-        await dbm.saveFile(collectionName, player, charData2);
+        await dbm.saveFile(collectionName, String(playerGiving), charData);
+        await dbm.saveFile(collectionName, String(player), charData2);
         return true;
       } else {
         return "You don't have enough of that item!";
@@ -1769,8 +1769,8 @@ class char {
       if (charData.balance >= gold) {
         charData.balance -= gold;
         charData2.balance += gold;
-        await dbm.saveFile(collectionName, playerGiving, charData);
-        await dbm.saveFile(collectionName, player, charData2);
+        await dbm.saveFile(collectionName, String(playerGiving), charData);
+        await dbm.saveFile(collectionName, String(player), charData2);
         return true;
       } else {
         return "You don't have enough gold!";
@@ -1780,25 +1780,12 @@ class char {
 
 
 
-  static async findPlayerData(player) {
-    let collectionName = 'characters';
-    //Load collection
-    let data = await dbm.loadCollection(collectionName);
-    //Find if player can be found easily, if yes return player and charData
-    if (data[player]) {
-      return [player, data[player]];
-    } else {
-      //If not, try to find player by numeric ID
-      //Player ID that would be passed is surrounded by <@{ID}>, so need to remove those to find id
-      player = player.replace("<@", "");
-      player = player.replace(">", "");
-      for (let [key, value] of Object.entries(data)) {
-        if (value.numericID === player) {
-          return [key, value];
-        }
-      }
+  static async findPlayerData(id) {
+    const player = String(id);
+    const charData = await dbm.loadFile('characters', player);
+    if (charData) {
+      return [player, charData];
     }
-    //If player cannot be found, return false
     return [false, false];
   }
 }

--- a/commands/adminCommands/addembed.js
+++ b/commands/adminCommands/addembed.js
@@ -31,7 +31,7 @@ module.exports = {
             await interaction.reply({ content: 'Embed menu should appear below', ephemeral: true });
 
             // Show the map menu
-            let reply = await admin.editMapMenu(map, interaction.user.tag, type);
+            let reply = await admin.editMapMenu(map, interaction.user.id, type);
             if (typeof(reply) == 'string') {
                 await interaction.followUp(reply);
             } else {

--- a/commands/adminCommands/editembedaboutmodal.js
+++ b/commands/adminCommands/editembedaboutmodal.js
@@ -10,7 +10,7 @@ module.exports = {
         .setDefaultMemberPermissions(0),
     async execute(interaction) {
         try {
-            let mapName = await dbm.loadFile('characters', interaction.user.tag);   
+            let mapName = await dbm.loadFile('characters', interaction.user.id);
             
             mapName = mapName.editingFields["Map Edited"];
             let mapTypeEdited = mapName.editingFields["Map Type Edited"];

--- a/commands/adminCommands/editembedfield.js
+++ b/commands/adminCommands/editembedfield.js
@@ -26,7 +26,7 @@ module.exports = {
             newValue = interaction.options.getString('newvalue');
         }
 
-        let reply = await admin.editMapField(interaction.user.tag, fieldNumber, newValue);
+        let reply = await admin.editMapField(interaction.user.id, fieldNumber, newValue);
         if (typeof(reply) == 'string') {
             await interaction.reply(reply);
         } else {

--- a/commands/adminCommands/editembedmenu.js
+++ b/commands/adminCommands/editembedmenu.js
@@ -26,7 +26,7 @@ module.exports = {
 
         (async () => {
             //addIncome(roleID, incomeString)
-            let reply = await admin.editMapMenu(role, interaction.user.tag, type);
+            let reply = await admin.editMapMenu(role, interaction.user.id, type);
             if (typeof(reply) == 'string') {
                 await interaction.reply(reply);
             } else {

--- a/commands/adminCommands/editincomefield.js
+++ b/commands/adminCommands/editincomefield.js
@@ -29,7 +29,7 @@ module.exports = {
             newValue = "DELETEFIELD";
         }
 
-        let reply = await admin.editIncomeField(fieldNumber, interaction.user.tag, newValue);
+        let reply = await admin.editIncomeField(fieldNumber, interaction.user.id, newValue);
         if (typeof(reply) == 'string') {
             await interaction.reply(reply);
         } else {

--- a/commands/adminCommands/editincomemenu.js
+++ b/commands/adminCommands/editincomemenu.js
@@ -16,7 +16,7 @@ module.exports = {
 
         (async () => {
             //addIncome(roleID, incomeString)
-            let reply = await admin.editIncomeMenu(role, interaction.user.tag);
+            let reply = await admin.editIncomeMenu(role, interaction.user.id);
             if (typeof(reply) == 'string') {
                 await interaction.reply(reply);
             } else {

--- a/commands/charCommands/additemstoplayer.js
+++ b/commands/charCommands/additemstoplayer.js
@@ -12,7 +12,7 @@ module.exports = {
         .addStringOption(option => option.setName('item').setDescription('The item to add').setRequired(true))
         .addIntegerOption(option => option.setName('amount').setDescription('The amount of items to add').setRequired(true)),
     async execute(interaction) {
-        const player = interaction.options.getUser('player').toString();
+        const player = interaction.options.getUser('player').id;
         const item = interaction.options.getString('item');
         const amount = interaction.options.getInteger('amount');
         const response = await char.addItemToPlayer(player, item, amount);

--- a/commands/charCommands/addplayergold.js
+++ b/commands/charCommands/addplayergold.js
@@ -9,7 +9,7 @@ module.exports = {
         .addIntegerOption(option => option.setName('gold').setDescription('The amount of gold to set').setRequired(true))
         .setDefaultMemberPermissions(0),
     async execute(interaction) {
-        const player = interaction.options.getUser('player').toString();
+        const player = interaction.options.getUser('player').id;
         const gold = interaction.options.getInteger('gold');
         const response = await char.addPlayerGold(player, gold);
 

--- a/commands/charCommands/balance.js
+++ b/commands/charCommands/balance.js
@@ -6,7 +6,7 @@ module.exports = {
 		.setName('balance')
 		.setDescription('Show balance'),
 	async execute(interaction) {
-		const charID = interaction.user.tag;
+                const charID = interaction.user.id;
 
 		await interaction.deferReply({ ephemeral: true });
 

--- a/commands/charCommands/balanceadmin.js
+++ b/commands/charCommands/balanceadmin.js
@@ -1,6 +1,5 @@
 const { SlashCommandBuilder } = require('discord.js');
 const char = require('../../char'); // Importing the database manager
-const dataGetters = require('../../dataGetters');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -8,10 +7,8 @@ module.exports = {
 		.setDescription('Show balance of a player')
         .addUserOption(option => option.setName('player').setDescription('The player to show the balance of').setRequired(true))
         .setDefaultMemberPermissions(0),
-	async execute(interaction) {
-		const charResponse = interaction.options.getUser('player').toString();
-        const charNumeric = charResponse.substring(2, charResponse.length - 1);
-		const charID = await dataGetters.getCharFromNumericID(charNumeric);
+        async execute(interaction) {
+                const charID = interaction.options.getUser('player').id;
 
 		(async () => {
             let replyEmbed = await char.balance(charID);

--- a/commands/charCommands/bank.js
+++ b/commands/charCommands/bank.js
@@ -6,7 +6,7 @@ module.exports = {
 		.setName('bank')
 		.setDescription('Show bank'),
 	async execute(interaction) {
-		const charID = interaction.user.tag;
+                const charID = interaction.user.id;
 		await interaction.deferReply({ ephemeral: true });
 		const replyEmbed = await char.bank(charID);
 		if (typeof(replyEmbed) == 'string') {

--- a/commands/charCommands/changeplayerstats.js
+++ b/commands/charCommands/changeplayerstats.js
@@ -16,7 +16,7 @@ module.exports = {
         .addIntegerOption(option => option.setName('value').setDescription('The value to change stat by').setRequired(true))
         .setDefaultMemberPermissions(0),
     async execute(interaction) {
-        const player = interaction.options.getUser('player').toString();
+        const player = interaction.options.getUser('player').id;
         const stat = interaction.options.getString('stat');
         const value = interaction.options.getInteger('value');
         

--- a/commands/charCommands/char.js
+++ b/commands/charCommands/char.js
@@ -6,7 +6,7 @@ module.exports = {
 		.setName('char')
 		.setDescription('Show player character'),
 	execute(interaction) {
-		const charID = interaction.user.tag;
+                const charID = interaction.user.id;
 
 		(async () => {
             let replyEmbed = await char.char(charID);

--- a/commands/charCommands/charadmin.js
+++ b/commands/charCommands/charadmin.js
@@ -1,6 +1,5 @@
 const { SlashCommandBuilder } = require('discord.js');
 const char = require('../../char'); // Importing the database manager
-const dataGetters = require('../../dataGetters');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -12,11 +11,8 @@ module.exports = {
 				.setDescription('The character to check')
 				.setRequired(true)
 		),
-	async execute(interaction) {
-		const charResponse = interaction.options.getUser('character').toString();
-		//char is a string starting with <@ and ending with >
-		const charNumeric = charResponse.substring(2, charResponse.length - 1);
-		const charID = await dataGetters.getCharFromNumericID(charNumeric);
+        async execute(interaction) {
+                const charID = interaction.options.getUser('character').id;
 
 		(async () => {
             let replyEmbed = await char.char(charID);

--- a/commands/charCommands/crafting.js
+++ b/commands/charCommands/crafting.js
@@ -7,7 +7,7 @@ module.exports = {
         .setDescription('View crafting cooldowns'),
     async execute(interaction) {
         try {
-            const userID = interaction.user.tag;
+            const userID = interaction.user.id;
             var replyEmbed = await char.craftingCooldowns(userID);
             await interaction.reply(({ embeds: [replyEmbed] }));
         } catch (error) {

--- a/commands/charCommands/deposit.js
+++ b/commands/charCommands/deposit.js
@@ -10,7 +10,7 @@ module.exports = {
                 .setDescription('Quantity to deposit')
                 .setRequired(true)),
 	execute(interaction) {
-		const charID = interaction.user.tag;
+                const charID = interaction.user.id;
         const quantity = interaction.options.getInteger('quantity');
 
 		(async () => {

--- a/commands/charCommands/editchar.js
+++ b/commands/charCommands/editchar.js
@@ -6,7 +6,7 @@ module.exports = {
 		.setName('editchar')
 		.setDescription('Edit your character'),
 	async execute(interaction) {
-        placeholderArray = await char.editCharPlaceholders(interaction.user.tag);
+        placeholderArray = await char.editCharPlaceholders(interaction.user.id);
 
 		// Create the modal
 		const modal = new ModalBuilder()

--- a/commands/charCommands/givegold.js
+++ b/commands/charCommands/givegold.js
@@ -11,8 +11,8 @@ module.exports = {
         .addUserOption(option => option.setName('player').setDescription('The player to give gold to').setRequired(true))
         .addIntegerOption(option => option.setName('amount').setDescription('The amount of gold to give').setRequired(true)),
     async execute(interaction) {
-        const playerGiving = interaction.user.toString();
-        const player = interaction.options.getUser('player').toString();
+        const playerGiving = interaction.user.id;
+        const player = interaction.options.getUser('player').id;
         const amount = interaction.options.getInteger('amount');
         const response = await char.giveGoldToPlayer(playerGiving, player, amount);
 

--- a/commands/charCommands/giveitem.js
+++ b/commands/charCommands/giveitem.js
@@ -11,8 +11,8 @@ module.exports = {
         .addStringOption(option => option.setName('item').setDescription('The item to give').setRequired(true))
         .addIntegerOption(option => option.setName('amount').setDescription('The amount of items to give').setRequired(false)),
     async execute(interaction) {
-        const playerGiving = interaction.user.toString();
-        const player = interaction.options.getUser('player').toString();
+        const playerGiving = interaction.user.id;
+        const player = interaction.options.getUser('player').id;
         const item = interaction.options.getString('item');
         let amount = interaction.options.getInteger('amount');
         if (!amount) {

--- a/commands/charCommands/grab.js
+++ b/commands/charCommands/grab.js
@@ -14,7 +14,7 @@ module.exports = {
                 .setDescription('Quantity to grab')
                 .setRequired(true)),
 	execute(interaction) {
-		const charID = interaction.user.tag;
+                const charID = interaction.user.id;
         const item = interaction.options.getString('item');
         const quantity = interaction.options.getInteger('quantity');
 

--- a/commands/charCommands/incomes.js
+++ b/commands/charCommands/incomes.js
@@ -6,13 +6,12 @@ module.exports = {
 		.setName('incomes')
 		.setDescription('Collect your daily incomes'),
         async execute(interaction) {
-                const userID = interaction.user.tag;
                 const numericID = interaction.user.id;
                 const roles = interaction.member.roles.cache;
 
                 await interaction.deferReply({ ephemeral: true });
 
-                const [replyEmbed, replyString] = await char.incomes(userID, numericID, roles);
+                const [replyEmbed, replyString] = await char.incomes(numericID, roles);
                 await interaction.editReply({ embeds: [replyEmbed] });
                 if (replyString) {
                         await interaction.followUp({ content: replyString, ephemeral: true });

--- a/commands/charCommands/me.js
+++ b/commands/charCommands/me.js
@@ -6,7 +6,7 @@ module.exports = {
 		.setName('me')
 		.setDescription('Show player character- only RP aspects'),
 	execute(interaction) {
-		const charID = interaction.user.tag;
+                const charID = interaction.user.id;
 
 		(async () => {
             let replyEmbed = await char.me(charID);

--- a/commands/charCommands/say.js
+++ b/commands/charCommands/say.js
@@ -14,7 +14,7 @@ module.exports = {
         const message = interaction.options.getString('message');
 
 		(async () => {
-            let reply = await char.say(interaction.user.tag, message, interaction.channel)
+            let reply = await char.say(interaction.user.id, message, interaction.channel)
             if (typeof(reply) == 'string') {
                 await interaction.reply({ content: reply, ephemeral: true });
             } else {

--- a/commands/charCommands/setavatar.js
+++ b/commands/charCommands/setavatar.js
@@ -11,12 +11,12 @@ module.exports = {
 			.setRequired(true)
 		),
 	execute(interaction) {
-		const avatarURL = interaction.options.getString('avatarurl');
-		const userID = interaction.user.tag;
+                const avatarURL = interaction.options.getString('avatarurl');
+                const userID = interaction.user.id;
 
-		(async () => {
-			let replyString = await char.setAvatar(avatarURL, userID)
-			await interaction.reply(replyString);
-		})()
+                (async () => {
+                        let replyString = await char.setAvatar(avatarURL, userID)
+                        await interaction.reply(replyString);
+                })()
 	},
 };

--- a/commands/charCommands/setplayergold.js
+++ b/commands/charCommands/setplayergold.js
@@ -9,7 +9,7 @@ module.exports = {
         .addIntegerOption(option => option.setName('gold').setDescription('The amount of gold to set').setRequired(true))
         .setDefaultMemberPermissions(0),
     async execute(interaction) {
-        const player = interaction.options.getUser('player').toString();
+        const player = interaction.options.getUser('player').id;
         const gold = interaction.options.getInteger('gold');
         const response = await char.setPlayerGold(player, gold);
 

--- a/commands/charCommands/stats.js
+++ b/commands/charCommands/stats.js
@@ -6,7 +6,7 @@ module.exports = {
 		.setName('stats')
 		.setDescription('Show player stats'),
 	execute(interaction) {
-		const charID = interaction.user.tag;
+                const charID = interaction.user.id;
 
 		(async () => {
             let replyEmbed = await char.stats(charID);

--- a/commands/charCommands/store.js
+++ b/commands/charCommands/store.js
@@ -14,7 +14,7 @@ module.exports = {
                 .setDescription('Quantity to store')
                 .setRequired(true)),
 	execute(interaction) {
-		const charID = interaction.user.tag;
+                const charID = interaction.user.id;
         const item = interaction.options.getString('item');
         const quantity = interaction.options.getInteger('quantity');
 

--- a/commands/charCommands/takeitemsfromplayer.js
+++ b/commands/charCommands/takeitemsfromplayer.js
@@ -12,7 +12,7 @@ module.exports = {
         .addStringOption(option => option.setName('item').setDescription('The item to take').setRequired(true))
         .addIntegerOption(option => option.setName('amount').setDescription('The amount of items to take').setRequired(true)),
     async execute(interaction) {
-        const player = interaction.options.getUser('player').toString();
+        const player = interaction.options.getUser('player').id;
         const item = interaction.options.getString('item');
         const amount = interaction.options.getInteger('amount');
         const response = await char.addItemToPlayer(player, item, -amount);

--- a/commands/charCommands/transfergold.js
+++ b/commands/charCommands/transfergold.js
@@ -13,8 +13,8 @@ module.exports = {
         .addUserOption(option => option.setName('playergetting').setDescription('The player to give gold to').setRequired(true))
         .addIntegerOption(option => option.setName('amount').setDescription('The amount of gold to give').setRequired(true)),
     async execute(interaction) {
-        const playerGiving = interaction.options.getUser('playergiving').toString();
-        const player = interaction.options.getUser('playergetting').toString();
+        const playerGiving = interaction.options.getUser('playergiving').id;
+        const player = interaction.options.getUser('playergetting').id;
         const amount = interaction.options.getInteger('amount');
         const response = await char.giveGoldToPlayer(playerGiving, player, amount);
 

--- a/commands/charCommands/useitem.js
+++ b/commands/charCommands/useitem.js
@@ -20,7 +20,7 @@ module.exports = {
         const numberItems = interaction.options.getInteger('numbertouse');
 
 		(async () => {
-            let reply = await char.useItem(itemName, interaction.user.tag, numberItems)
+            let reply = await char.useItem(itemName, interaction.user.id, numberItems)
             if (typeof(reply) == 'string') {
                 await interaction.reply(reply);
             } else {

--- a/commands/charCommands/warn.js
+++ b/commands/charCommands/warn.js
@@ -10,7 +10,7 @@ module.exports = {
         .setDefaultMemberPermissions(0)
         .addUserOption(option => option.setName('player').setDescription('The player to warn').setRequired(true)),
     async execute(interaction) {
-        const player = interaction.options.getUser('player').tag;
+        const player = interaction.options.getUser('player').id;
         const response = await char.warn(player);
 
         return interaction.reply(response);

--- a/commands/charCommands/warnings.js
+++ b/commands/charCommands/warnings.js
@@ -9,7 +9,7 @@ module.exports = {
         .setDescription('Check warnings')
         .addUserOption(option => option.setName('player').setDescription('The player to check warnings of').setRequired(false)),
     async execute(interaction) {
-        const player = interaction.options.getUser('player')?.tag || interaction.user.tag;
+        const player = interaction.options.getUser('player')?.id || interaction.user.id;
         const response = await char.checkWarns(player);
 
         return interaction.reply(response);

--- a/commands/charCommands/withdraw.js
+++ b/commands/charCommands/withdraw.js
@@ -10,7 +10,7 @@ module.exports = {
                 .setDescription('Quantity to withdraw')
                 .setRequired(true)),
 	execute(interaction) {
-		const charID = interaction.user.tag;
+                const charID = interaction.user.id;
         const quantity = interaction.options.getInteger('quantity');
 
 		(async () => {

--- a/commands/raid.js
+++ b/commands/raid.js
@@ -26,7 +26,7 @@ module.exports = {
     .setDescription('Launch a raid against one of the available targets'),
   async execute(interaction) {
     const userId = interaction.user.id;
-    const charId = interaction.user.tag;
+    const charId = String(interaction.user.id);
 
     const charData = await dbm.loadFile('characters', charId);
     if (!charData) {

--- a/interaction-handler.js
+++ b/interaction-handler.js
@@ -113,7 +113,6 @@ addItem = async (interaction) => {
 
 newChar = async (interaction) => {
   // Get the data entered by the user
-  const userID = interaction.user.tag;
   const numericID = interaction.user.id;
   const charName = interaction.fields.getTextInputValue('charname');
   const charBio = interaction.fields.getTextInputValue('charbio');
@@ -148,7 +147,7 @@ newChar = async (interaction) => {
 
   // Call the newChar function from the char class with the info
   if (charName && charBio) {
-    char.newChar(userID, charName, charBio, numericID);
+    char.newChar(numericID, charName, charBio);
     await interaction.reply(`Character '${charName}' has been created.`);
   } else {
     // Handle missing information


### PR DESCRIPTION
## Summary
- Store and retrieve character data by numeric Discord ID instead of tag
- Simplify player lookup with direct database fetches
- Update commands to supply `interaction.user.id` when calling character APIs

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b7785a1208832e944931232064b256