### PR TITLE
Use numeric IDs for character data

### DIFF
--- a/admin.js
+++ b/admin.js
@@ -327,7 +327,7 @@ When selected grants the:
     return newMapName;
   }
 
-  static async editMapMenu(mapName, tag, mapType = "map") {
+  static async editMapMenu(mapName, numericID, mapType = "map") {
     // Load the map data
     let mapData = await dbm.loadFile('keys', mapType + 's');
   
@@ -345,13 +345,13 @@ When selected grants the:
   
     mapData = mapData[mapName];
   
-    let userData = await dbm.loadFile('characters', tag);
+    let userData = await dbm.loadFile('characters', String(numericID));
     if (!userData.editingFields) {
       userData.editingFields = {};
     }
     userData.editingFields["Map Edited"] = mapName;
     userData.editingFields["Map Type Edited"] = mapType;
-    await dbm.saveFile('characters', tag, userData);
+    await dbm.saveFile('characters', String(numericID), userData);
   
     // Construct the edit menu embed
     const embed = new EmbedBuilder()
@@ -414,9 +414,9 @@ When selected grants the:
     interaction.reply("About section has been updated");
   }
   
-  static async editMapField(charTag, field, value) {
+  static async editMapField(numericID, field, value) {
     // Load the maps collection
-    let charData = await dbm.loadFile('characters', charTag);
+    let charData = await dbm.loadFile('characters', String(numericID));
     if (!charData.editingFields || !charData.editingFields["Map Edited"] || !charData.editingFields["Map Type Edited"]) {
       return "You must use /editmapmenu first to select a map to edit";
     }
@@ -576,8 +576,8 @@ When selected grants the:
     let guild = interaction.guild;
     let user = await guild.members.fetch(interaction.user.id);
 
-    let userTag = interaction.user.tag;
-    let char = await dbm.loadFile("characters", userTag);
+    const numericID = interaction.user.id;
+    let char = await dbm.loadFile("characters", String(numericID));
     //add all shires from all kingdoms to a new tempShires object
     let tempShires = {};
     for (const kingdom in kingdoms) {
@@ -635,7 +635,7 @@ When selected grants the:
 
     await user.roles.add(role);
     await user.roles.add(kingdomRole);
-    await dbm.saveFile("characters", userTag, char);
+    await dbm.saveFile("characters", String(numericID), char);
 
 
     await interaction.reply({ 
@@ -652,8 +652,8 @@ When selected grants the:
     let guild = interaction.guild;
     let user = await guild.members.fetch(interaction.user.id);
 
-    let userTag = interaction.user.tag;
-    let char = await dbm.loadFile("characters", userTag);
+    const numericID = interaction.user.id;
+    let char = await dbm.loadFile("characters", String(numericID));
     for (const role of user.roles.cache) {
       if (Object.values(tradeNodes).some(tradeNode => tradeNode.roleCode == role[1].id)) {
         await interaction.reply({ content: "You are already a member of a trade node! You cannot switch trade nodes", ephemeral: true });
@@ -676,7 +676,7 @@ When selected grants the:
 
     await user.roles.add(role);
     char.tradeNodeID = selectedTradeNode;
-    await dbm.saveFile("characters", userTag, char);
+    await dbm.saveFile("characters", String(numericID), char);
 
     await interaction.reply({ 
       content: "You have selected " + tradeNode.name + " as your trade node", 
@@ -692,8 +692,8 @@ When selected grants the:
     let guild = interaction.guild;
     let user = await guild.members.fetch(interaction.user.id);
 
-    let userTag = interaction.user.tag;
-    let char = await dbm.loadFile("characters", userTag);
+    const numericID = interaction.user.id;
+    let char = await dbm.loadFile("characters", String(numericID));
     for (const role of user.roles.cache) {
       if (Object.values(resources).some(resource => resource.roleCode == role[1].id)) {
         await interaction.reply({ content: "You are already a producer of a resource! You cannot switch resources", ephemeral: true });
@@ -716,7 +716,7 @@ When selected grants the:
 
     await user.roles.add(role);
     char.resourceID = selectedResource;
-    await dbm.saveFile("characters", userTag, char);
+    await dbm.saveFile("characters", String(numericID), char);
 
     await interaction.reply({ 
       content: "You have selected " + resource.emoji + resource.name, 
@@ -739,8 +739,8 @@ When selected grants the:
       classBaseRoleName = "Trader Base Role";
     }
 
-    let userTag = interaction.user.tag;
-    let char = await dbm.loadFile("characters", userTag);
+    const numericID = interaction.user.id;
+    let char = await dbm.loadFile("characters", String(numericID));
     for (const role of user.roles.cache) {
       if (role[1].name == "Trader" || role[1].name == "Farmer") {
         await interaction.reply({ content: "You are already a member of a class! You cannot switch classes", ephemeral: true });
@@ -783,8 +783,8 @@ When selected grants the:
     let guild = interaction.guild;
     let user = await guild.members.fetch(interaction.user.id);
 
-    let userTag = interaction.user.tag;
-    let char = await dbm.loadFile("characters", userTag);
+    const numericID = interaction.user.id;
+    let char = await dbm.loadFile("characters", String(numericID));
     for (const role of user.roles.cache) {
       if (Object.values(parties).some(party => party.name.toLowerCase() == role[1].name.toLowerCase())) {
         await interaction.reply({ content: "You are already a member of a party! You cannot switch parties", ephemeral: true });
@@ -799,7 +799,7 @@ When selected grants the:
 
     await user.roles.add(role);
     char.partyID = selectedParty;
-    await dbm.saveFile("characters", userTag, char);
+    await dbm.saveFile("characters", String(numericID), char);
 
     await interaction.reply({ 
       content: "You have selected " + party.emoji + party.name + "\n\n" + party.motto, 

--- a/commands/salesCommands/buysale.js
+++ b/commands/salesCommands/buysale.js
@@ -1,4 +1,4 @@
-//Passes saleID, userTag, userID to buySale function in marketplace.js
+//Passes saleID and numericID to buySale function in marketplace.js
 
 const { SlashCommandBuilder } = require('@discordjs/builders');
 const marketplace = require('../../marketplace');
@@ -14,9 +14,8 @@ module.exports = {
         ),
     async execute(interaction) {
         const saleID = interaction.options.getString('saleid');
-        const userTag = interaction.user.tag;
-        const userID = interaction.user.id;
-        let replyString = await marketplace.buySale(saleID, userTag, userID);
+        const numericID = interaction.user.id;
+        let replyString = await marketplace.buySale(saleID, numericID);
         //if embed, display embed, otherwise display string
         if (typeof (replyString) == 'string') {
             await interaction.reply(replyString);

--- a/commands/salesCommands/sell.js
+++ b/commands/salesCommands/sell.js
@@ -25,9 +25,10 @@ module.exports = {
         const itemName = interaction.options.getString('itemname');
         const quantity = interaction.options.getInteger('quantity');
         const price = interaction.options.getInteger('price');
+        const numericID = interaction.user.id;
 
         (async () => {
-            let reply = await marketplace.postSale(quantity, itemName, price, interaction.user.tag, interaction.user.id)
+            let reply = await marketplace.postSale(quantity, itemName, price, numericID)
             if (typeof (reply) == 'string') {
                 await interaction.reply(reply);
             } else {

--- a/commands/salesCommands/showsales.js
+++ b/commands/salesCommands/showsales.js
@@ -2,7 +2,6 @@
 
 const { SlashCommandBuilder } = require('@discordjs/builders');
 const marketplace = require('../../marketplace');
-const dataGetters = require('../../dataGetters');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -29,11 +28,9 @@ module.exports = {
             page = 1;
         }
 
-        player = await dataGetters.getCharFromNumericID(player.id);
+        const playerID = player.id;
 
-        if (process.env.DEBUG) console.log(player);
-
-        let replyString = await marketplace.showSales(player, page);
+        let replyString = await marketplace.showSales(playerID, page);
         //if embed, display embed, otherwise display string
         if (typeof (replyString) == 'string') {
             await interaction.reply(replyString);

--- a/commands/shopCommands/addrecipe.js
+++ b/commands/shopCommands/addrecipe.js
@@ -23,7 +23,8 @@ module.exports = {
         await interaction.reply({ content: 'Edit recipe menu should appear below', ephemeral: true });
 
         // Show the edit recipe menu
-        let reply = await shop.editRecipeMenu(recipeName, interaction.user.tag);
+        const numericID = interaction.user.id;
+        let reply = await shop.editRecipeMenu(recipeName, numericID);
         if (typeof(reply) == 'string') {
             await interaction.followUp(reply);
         } else {

--- a/commands/shopCommands/buyitem.js
+++ b/commands/shopCommands/buyitem.js
@@ -18,11 +18,12 @@ module.exports = {
 	execute(interaction) {
 		const itemName = interaction.options.getString('itemname');
         const numberItems = interaction.options.getInteger('numbertobuy');
+        const numericID = interaction.user.id;
 
-		(async () => {
-            let reply = await shop.buyItem(itemName, interaction.user.tag, numberItems, interaction.channelId)
+                (async () => {
+            let reply = await shop.buyItem(itemName, numericID, numberItems, interaction.channelId)
             interaction.reply(reply);
-			// Call the addItem function from the Shop class
-		})()
-	},
+                        // Call the addItem function from the Shop class
+                })()
+        },
 };

--- a/commands/shopCommands/edititemfield.js
+++ b/commands/shopCommands/edititemfield.js
@@ -22,8 +22,8 @@ module.exports = {
         const newValue = interaction.options.getString('newvalue');
 
         if (process.env.DEBUG) console.log('new value: ' + newValue);
-
-        let reply = await shop.editItemField(interaction.user.tag, fieldNumber, newValue);
+        const numericID = interaction.user.id;
+        let reply = await shop.editItemField(numericID, fieldNumber, newValue);
         await interaction.reply(reply);
     }
 };

--- a/commands/shopCommands/edititemmenu.js
+++ b/commands/shopCommands/edititemmenu.js
@@ -16,7 +16,8 @@ module.exports = {
         await interaction.deferReply();
 
         // shop.editItemMenu returns an array with the first element being the replyEmbed and the second element being the rows
-        const reply = await shop.editItemMenu(itemName, 1, interaction.user.tag);
+        const numericID = interaction.user.id;
+        const reply = await shop.editItemMenu(itemName, 1, numericID);
         if (typeof reply === 'string') {
             await interaction.editReply(reply);
         } else {

--- a/commands/shopCommands/editrecipefield.js
+++ b/commands/shopCommands/editrecipefield.js
@@ -20,8 +20,8 @@ module.exports = {
     async execute(interaction) {
         const fieldNumber = interaction.options.getInteger('fieldnumber');
         const newValue = interaction.options.getString('newvalue');
-
-        let reply = await shop.editRecipeField(interaction.user.tag, fieldNumber, newValue);
+        const numericID = interaction.user.id;
+        let reply = await shop.editRecipeField(numericID, fieldNumber, newValue);
         await interaction.reply(reply);
     }
 };

--- a/commands/shopCommands/editrecipemenu.js
+++ b/commands/shopCommands/editrecipemenu.js
@@ -12,11 +12,12 @@ module.exports = {
 			.setRequired(true)
 		),
 	execute(interaction) {
-		const recipeName = interaction.options.getString('recipename');
+                const recipeName = interaction.options.getString('recipename');
 
-		(async () => {
-			//shop.editrecipeMenu returns an array with the first element being the replyEmbed and the second element being the rows
-			let reply = await shop.editRecipeMenu(recipeName, interaction.user.tag);
+                (async () => {
+                        //shop.editrecipeMenu returns an array with the first element being the replyEmbed and the second element being the rows
+                        const numericID = interaction.user.id;
+                        let reply = await shop.editRecipeMenu(recipeName, numericID);
             if (typeof(reply) == 'string') {
                 await interaction.reply(reply);
             } else {

--- a/interaction-handler.js
+++ b/interaction-handler.js
@@ -182,7 +182,8 @@ allItemSwitch = async (interaction) => {
   await interaction.update({ embeds: [edittedEmbed], components: rows});
 }
 itemSwitch = async (interaction) => {
-  let [edittedEmbed, rows] = await shop.editItemMenu(interaction.customId.substring(12), interaction.customId[11], interaction.user.tag);
+  const numericID = interaction.user.id;
+  let [edittedEmbed, rows] = await shop.editItemMenu(interaction.customId.substring(12), interaction.customId[11], numericID);
   await interaction.update({ embeds: [edittedEmbed], components: [rows]});
 }
 balaSwitch = async (interaction) => {


### PR DESCRIPTION
## Summary
- replace user tag based lookups with numeric Discord IDs
- update marketplace and shop helpers to work with numeric IDs
- drop tag conversion utilities and remove legacy tag variables

## Testing
- `npm test` *(fails: Missing script: "test")*
- `rg 'interaction\.user\.tag'`
- `rg 'userTag' -n`

------
https://chatgpt.com/codex/tasks/task_e_68b81ee3a6b0832e92073dc00482addd