### PR TITLE
Refactor marketplace to use character IDs

### DIFF
--- a/commands/salesCommands/buysale.js
+++ b/commands/salesCommands/buysale.js
@@ -1,4 +1,4 @@
-//Passes saleID and numericID to buySale function in marketplace.js
+//Passes saleID and buyerID to buySale function in marketplace.js
 
 const { SlashCommandBuilder } = require('@discordjs/builders');
 const marketplace = require('../../marketplace');
@@ -14,8 +14,8 @@ module.exports = {
         ),
     async execute(interaction) {
         const saleID = interaction.options.getString('saleid');
-        const numericID = interaction.user.id;
-        let replyString = await marketplace.buySale(saleID, numericID);
+        const buyerID = interaction.user.id;
+        let replyString = await marketplace.buySale(saleID, buyerID);
         //if embed, display embed, otherwise display string
         if (typeof (replyString) == 'string') {
             await interaction.reply(replyString);

--- a/commands/salesCommands/sell.js
+++ b/commands/salesCommands/sell.js
@@ -25,10 +25,10 @@ module.exports = {
         const itemName = interaction.options.getString('itemname');
         const quantity = interaction.options.getInteger('quantity');
         const price = interaction.options.getInteger('price');
-        const numericID = interaction.user.id;
+        const sellerID = interaction.user.id;
 
         (async () => {
-            let reply = await marketplace.postSale(quantity, itemName, price, numericID)
+            let reply = await marketplace.postSale(quantity, itemName, price, sellerID);
             if (typeof (reply) == 'string') {
                 await interaction.reply(reply);
             } else {

--- a/commands/salesCommands/showsales.js
+++ b/commands/salesCommands/showsales.js
@@ -18,19 +18,19 @@ module.exports = {
                 .setRequired(false)
         ),
     async execute(interaction) {
-        let player = interaction.options.getUser('player');
+        let seller = interaction.options.getUser('player');
         let page = interaction.options.getInteger('page');
-        if (process.env.DEBUG) console.log(player);
-        if (!player) {
-            player = interaction.user;
+        if (process.env.DEBUG) console.log(seller);
+        if (!seller) {
+            seller = interaction.user;
         }
         if (!page) {
             page = 1;
         }
 
-        const playerID = player.id;
+        const sellerID = seller.id;
 
-        let replyString = await marketplace.showSales(playerID, page);
+        let replyString = await marketplace.showSales(sellerID, page);
         //if embed, display embed, otherwise display string
         if (typeof (replyString) == 'string') {
             await interaction.reply(replyString);


### PR DESCRIPTION
## Summary
- Use seller and buyer IDs in marketplace functions and character storage
- Pass interaction.user.id through sales commands
- Display seller tags only in embeds

## Testing
- `npm test` *(fails: Missing script "test")*
- `node --check marketplace.js`
- `node --check commands/salesCommands/sell.js`
- `node --check commands/salesCommands/buysale.js`
- `node --check commands/salesCommands/showsales.js`


------
https://chatgpt.com/codex/tasks/task_e_68b825212f0c832e9714ac22f0accafb