### PR TITLE
Use numeric IDs for character edit sessions

### DIFF
--- a/admin.js
+++ b/admin.js
@@ -1110,7 +1110,7 @@ When selected grants the:
     return [returnEmbed, [actionRow]];
   }
 
-  static async editIncomeMenu(income, charTag) {
+  static async editIncomeMenu(income, numericID) {
     let incomeList = await dbm.loadFile("keys", "incomeList");
     let incomeValue = incomeList[income];
     if (incomeValue == undefined) {
@@ -1170,18 +1170,21 @@ When selected grants the:
         "\n`[7] Income Delay: ` " + delayString
       );
 
-    let userData = await dbm.loadFile("characters", charTag);
+    let userData = await dbm.loadFile("characters", String(numericID));
+    if (!userData) {
+      userData = {};
+    }
     if (!userData.editingFields) {
       userData.editingFields = {};
     }
     userData.editingFields["Income Edited"] = income;
-    await dbm.saveFile("characters", charTag, userData);
+    await dbm.saveFile("characters", String(numericID), userData);
 
     return returnEmbed;
   }
 
-  static async editIncomeField(fieldNumber, charTag, newValue) {
-    let userData = await dbm.loadFile("characters", charTag)
+  static async editIncomeField(fieldNumber, numericID, newValue) {
+    let userData = await dbm.loadFile("characters", String(numericID));
     let editingFields = userData.editingFields;
     let income = editingFields["Income Edited"];
     let incomeList = await dbm.loadFile("keys", "incomeList");
@@ -1199,6 +1202,8 @@ When selected grants the:
         }
         delete incomeList[income];
         income = newValue;
+        userData.editingFields["Income Edited"] = income;
+        await dbm.saveFile("characters", String(numericID), userData);
         break;
       case 2:
         if (newValue == "DELETEFIELD") {

--- a/commands/adminCommands/editembedaboutmodal.js
+++ b/commands/adminCommands/editembedaboutmodal.js
@@ -10,10 +10,10 @@ module.exports = {
         .setDefaultMemberPermissions(0),
     async execute(interaction) {
         try {
-            let mapName = await dbm.loadFile('characters', interaction.user.id);
-            
-            mapName = mapName.editingFields["Map Edited"];
-            let mapTypeEdited = mapName.editingFields["Map Type Edited"];
+            let userData = await dbm.loadFile('characters', String(interaction.user.id));
+
+            let mapName = userData.editingFields["Map Edited"];
+            let mapTypeEdited = userData.editingFields["Map Type Edited"];
             
             let maps = await dbm.loadFile('keys', mapTypeEdited);
 


### PR DESCRIPTION
## Summary
- Use numeric user IDs instead of tags when editing shop items, recipes, and admin maps/incomes
- Persist each user's editing context under their numeric ID
- Fix embed about modal to read editing fields via numeric ID

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node -e "require('./admin.js'); require('./shop.js');"` *(fails: Missing required configuration: token, clientId, guildId, databaseUrl)*

------
https://chatgpt.com/codex/tasks/task_e_68b826d55e3c832ebb03f146d9e395f9