### PR TITLE
Standardize slash command replies with deferred edits

### DIFF
--- a/commands/adminCommands/addIncome.js
+++ b/commands/adminCommands/addIncome.js
@@ -17,6 +17,7 @@ module.exports = {
                 .setRequired(true)
         ),
     async execute(interaction) {
+            await interaction.deferReply({ flags: 64 });
         const role = interaction.options.getRole('role');
         const income = interaction.options.getString('income');
 
@@ -24,9 +25,9 @@ module.exports = {
             //addIncome(roleID, incomeString)
             let reply = await admin.addIncome(role, income);
             if (typeof(reply) == 'string') {
-                await interaction.reply(reply);
+                await interaction.editReply(reply);
             } else {
-                await interaction.reply({ embeds: [reply] });
+                await interaction.editReply({ embeds: [reply] });
             }
             // Call the useItem function from the Shop class
         })()

--- a/commands/adminCommands/addembed.js
+++ b/commands/adminCommands/addembed.js
@@ -20,6 +20,7 @@ module.exports = {
                     {name: 'Rank', value: 'rank'},
                     {name: 'Guide', value: 'guide'})),
 	async execute(interaction) {
+	        await interaction.deferReply({ flags: 64 });
 		try {
             let map = interaction.options.getString('embed');
             let type = interaction.options.getString('type');
@@ -29,7 +30,7 @@ module.exports = {
             map = await admin.addMap(map, guild, type);
 
             // Respons with an ephemeral message saying that map should appear below
-            await interaction.reply({ content: 'Embed menu should appear below', ephemeral: true });
+            await interaction.editReply({ content: 'Embed menu should appear below' });
 
             // Show the map menu
             let reply = await admin.editMapMenu(map, String(numericID), type);
@@ -40,7 +41,7 @@ module.exports = {
             }
         } catch (error) {
             console.error("Failed to add map menu:", error);
-            await interaction.reply({ content: "Failed to add the map. Please try again.", ephemeral: true });
+            await interaction.editReply({ content: "Failed to add the map. Please try again." });
         }
 	},
 };

--- a/commands/adminCommands/addplayerkingdoms.js
+++ b/commands/adminCommands/addplayerkingdoms.js
@@ -11,13 +11,14 @@ module.exports = {
                 .setRequired(true))
         .setDefaultMemberPermissions(0),
 	async execute(interaction) {
+	        await interaction.deferReply({ flags: 64 });
 		try {
             const kingdom = interaction.options.getRole('kingdom');
             await admin.addKingdom(kingdom);
-            await interaction.reply({ content: `Added the kingdom ${kingdom} to the list of player kingdoms.`, ephemeral: true });
+            await interaction.editReply({ content: `Added the kingdom ${kingdom} to the list of player kingdoms.` });
         } catch (error) {
             console.error("Failed to add map menu:", error);
-            await interaction.reply({ content: "Failed to add the kingdom. Please try again.", ephemeral: true });
+            await interaction.editReply({ content: "Failed to add the kingdom. Please try again." });
         }
 	},
 };

--- a/commands/adminCommands/allincomes.js
+++ b/commands/adminCommands/allincomes.js
@@ -7,7 +7,7 @@ module.exports = {
 		.setDescription('List all incomes')
 		.setDefaultMemberPermissions(0),
 	async execute(interaction) {
-        await interaction.deferReply();
+	        await interaction.deferReply({ flags: 64 });
 		try {
             let reply = await admin.allIncomes(1);
             if (typeof(reply) == 'string') {
@@ -18,7 +18,7 @@ module.exports = {
             }
         } catch (error) {
             console.error("Failed to get incomes", error);
-            await interaction.editReply({ content: "An error was caught. Contact Alex.", ephemeral: true });
+            await interaction.editReply({ content: "An error was caught. Contact Alex." });
         }
 	},
 };

--- a/commands/adminCommands/backupJson.js
+++ b/commands/adminCommands/backupJson.js
@@ -7,13 +7,13 @@ module.exports = {
 		.setDescription('Backup the JSON files')
 		.setDefaultMemberPermissions(0),
 	async execute(interaction) {
-		await interaction.deferReply();
+	        await interaction.deferReply({ flags: 64 });
         try {
             await dbm.logData();
             await interaction.editReply("Successfully backed up data.");
         } catch (error) {
             console.error("Failed to backup data", error);
-            await interaction.editReply({ content: "An error was caught. Contact Alex.", ephemeral: true });
+            await interaction.editReply({ content: "An error was caught. Contact Alex." });
         }
         },
 };

--- a/commands/adminCommands/deploycommands.js
+++ b/commands/adminCommands/deploycommands.js
@@ -9,7 +9,8 @@ module.exports = {
     .setDefaultMemberPermissions(0)
     .setDescription('Deploy map commands'),
   async execute(interaction) {
+          await interaction.deferReply({ flags: 64 });
     deploycommands.loadCommands();
-    await interaction.reply('Command files have been generated.');
+    await interaction.editReply('Command files have been generated.');
   },
 };

--- a/commands/adminCommands/editembedfield.js
+++ b/commands/adminCommands/editembedfield.js
@@ -18,6 +18,7 @@ module.exports = {
                 .setRequired(false)
         ),
     async execute(interaction) {
+            await interaction.deferReply({ flags: 64 });
         const fieldNumber = interaction.options.getInteger('fieldnumber');
         let newValue;
         if (interaction.options.getString('newvalue') == null) {
@@ -29,9 +30,9 @@ module.exports = {
         const numericID = interaction.user.id;
         let reply = await admin.editMapField(String(numericID), fieldNumber, newValue);
         if (typeof(reply) == 'string') {
-            await interaction.reply(reply);
+            await interaction.editReply(reply);
         } else {
-            await interaction.reply({ embeds: [reply] });
+            await interaction.editReply({ embeds: [reply] });
         }
     }
 };

--- a/commands/adminCommands/editembedmenu.js
+++ b/commands/adminCommands/editembedmenu.js
@@ -21,6 +21,7 @@ module.exports = {
                     {name: 'Rank', value: 'rank'},
                     {name: 'Guide', value: 'guide'})),
     async execute(interaction) {
+            await interaction.deferReply({ flags: 64 });
         const role = interaction.options.getString('embed');
         const type = interaction.options.getString('type');
         const numericID = interaction.user.id;
@@ -29,9 +30,9 @@ module.exports = {
             //addIncome(roleID, incomeString)
             let reply = await admin.editMapMenu(role, String(numericID), type);
             if (typeof(reply) == 'string') {
-                await interaction.reply(reply);
+                await interaction.editReply(reply);
             } else {
-                await interaction.reply({ embeds: [reply] });
+                await interaction.editReply({ embeds: [reply] });
             }
             // Call the useItem function from the Shop class
         })()

--- a/commands/adminCommands/editincomefield.js
+++ b/commands/adminCommands/editincomefield.js
@@ -18,10 +18,11 @@ module.exports = {
                 .setRequired(false)
         ),
     async execute(interaction) {
+            await interaction.deferReply({ flags: 64 });
         const fieldNumber = interaction.options.getInteger('fieldnumber');
         let newValue;
         if (interaction.options.getString('newvalue') == null) {
-            return await interaction.reply('If you want to remove a field, please make the new value "DELETE" in all caps');
+            return await interaction.editReply('If you want to remove a field, please make the new value "DELETE" in all caps');
         } else {
             newValue = interaction.options.getString('newvalue');
         }
@@ -32,9 +33,9 @@ module.exports = {
         const numericID = interaction.user.id;
         let reply = await admin.editIncomeField(fieldNumber, String(numericID), newValue);
         if (typeof(reply) == 'string') {
-            await interaction.reply(reply);
+            await interaction.editReply(reply);
         } else {
-            await interaction.reply({ embeds: [reply] });
+            await interaction.editReply({ embeds: [reply] });
         }
     }
 };

--- a/commands/adminCommands/editincomemenu.js
+++ b/commands/adminCommands/editincomemenu.js
@@ -12,6 +12,7 @@ module.exports = {
                 .setRequired(true)
         ),
     async execute(interaction) {
+            await interaction.deferReply({ flags: 64 });
         const role = interaction.options.getString('income');
         const numericID = interaction.user.id;
 
@@ -19,9 +20,9 @@ module.exports = {
             //addIncome(roleID, incomeString)
             let reply = await admin.editIncomeMenu(role, String(numericID));
             if (typeof(reply) == 'string') {
-                await interaction.reply(reply);
+                await interaction.editReply(reply);
             } else {
-                await interaction.reply({ embeds: [reply] });
+                await interaction.editReply({ embeds: [reply] });
             }
             // Call the useItem function from the Shop class
         })()

--- a/commands/adminCommands/embed.js
+++ b/commands/adminCommands/embed.js
@@ -20,6 +20,7 @@ module.exports = {
                 .setDescription('The name of the embed')
                 .setRequired(true)),
 	async execute(interaction) {
+	        await interaction.deferReply({ flags: 64 });
 		try {
             let type = interaction.options.getString('type');
             let embed = interaction.options.getString('embed');
@@ -27,13 +28,13 @@ module.exports = {
             // Call the method with the channel object directly
             let reply = await admin.map(embed, channelID, type);
             if (typeof(reply) == 'string') {
-                await interaction.reply(reply);
+                await interaction.editReply(reply);
             } else {
-                await interaction.reply({ embeds: [reply]});
+                await interaction.editReply({ embeds: [reply]});
             }
         } catch (error) {
             console.error("Failed to add map menu:", error);
-            await interaction.reply({ content: "Failed to add the map. Please try again.", ephemeral: true });
+            await interaction.editReply({ content: "Failed to add the map. Please try again." });
         }
 	},
 };

--- a/commands/adminCommands/embedlist.js
+++ b/commands/adminCommands/embedlist.js
@@ -16,7 +16,7 @@ module.exports = {
                     {name: 'Guide', value: 'guide'}))
 		.setDefaultMemberPermissions(0),
 	async execute(interaction) {
-        await interaction.deferReply();
+	        await interaction.deferReply({ flags: 64 });
 		try {
             let reply;
             switch (interaction.options.getString('type')) {
@@ -43,7 +43,7 @@ module.exports = {
             }
         } catch (error) {
             console.error("Failed to get incomes", error);
-            await interaction.editReply({ content: "An error was caught. Contact Alex.", ephemeral: true });
+            await interaction.editReply({ content: "An error was caught. Contact Alex." });
         }
 	},
 };

--- a/commands/adminCommands/guide.js
+++ b/commands/adminCommands/guide.js
@@ -10,7 +10,8 @@ module.exports = {
 			.setDescription('The guide name')
 			.setRequired(true)
 		),
-	execute(interaction) {
+	async execute(interaction) {
+	        await interaction.deferReply({ flags: 64 });
 		const guideName = interaction.options.getString('guide');
 
 		(async () => {
@@ -19,9 +20,9 @@ module.exports = {
 			// If the return is a string, it's an error message
             if (typeof(returnEmbed) == 'string') {
                 // If it's a string, it's an error message, ephemeral it
-                await interaction.reply({content: returnEmbed, ephemeral: true });
+                await interaction.editReply({content: returnEmbed });
             } else {
-                await interaction.reply({ embeds: [returnEmbed] });
+                await interaction.editReply({ embeds: [returnEmbed] });
             }
 			// Call the addItem function from the Shop class
 		})()

--- a/commands/adminCommands/initclassselectmenu.js
+++ b/commands/adminCommands/initclassselectmenu.js
@@ -7,13 +7,14 @@ module.exports = {
 		.setDescription('Initialize a class select menu here')
 		.setDefaultMemberPermissions(0),
 	async execute(interaction) {
+	        await interaction.deferReply({ flags: 64 });
 		try {
             // Call the method with the channel object directly
             await admin.initClassSelect(interaction.channel);
-            await interaction.reply({ content: "Set! Select menu should appear just below this message", ephemeral: true });
+            await interaction.editReply({ content: "Set! Select menu should appear just below this message" });
         } catch (error) {
             console.error("Failed to initialize select menu:", error);
-            await interaction.reply({ content: "Failed to set the select menu. Please try again.", ephemeral: true });
+            await interaction.editReply({ content: "Failed to set the select menu. Please try again." });
         }
 	},
 };

--- a/commands/adminCommands/initpartyselectmenus.js
+++ b/commands/adminCommands/initpartyselectmenus.js
@@ -7,13 +7,14 @@ module.exports = {
 		.setDescription('Initialize the menus to join a party')
 		.setDefaultMemberPermissions(0),
 	async execute(interaction) {
+	        await interaction.deferReply({ flags: 64 });
 		try {
             // Call the method with the channel object directly
             await admin.initPartySelect(interaction.channel);
-            await interaction.reply({ content: "Set! Select menus should appear just below this message", ephemeral: true });
+            await interaction.editReply({ content: "Set! Select menus should appear just below this message" });
         } catch (error) {
             console.error("Failed to initialize select menu:", error);
-            await interaction.reply({ content: "Failed to set the select menus. Please try again.", ephemeral: true });
+            await interaction.editReply({ content: "Failed to set the select menus. Please try again." });
         }
 	},
 };

--- a/commands/adminCommands/initresourceselectmenu.js
+++ b/commands/adminCommands/initresourceselectmenu.js
@@ -7,13 +7,14 @@ module.exports = {
 		.setDescription('Initialize a resource select menu here')
 		.setDefaultMemberPermissions(0),
 	async execute(interaction) {
+	        await interaction.deferReply({ flags: 64 });
 		try {
             // Call the method with the channel object directly
             await admin.initResourceSelect(interaction.channel);
-            await interaction.reply({ content: "Set! Select menu should appear just below this message", ephemeral: true });
+            await interaction.editReply({ content: "Set! Select menu should appear just below this message" });
         } catch (error) {
             console.error("Failed to initialize select menu:", error);
-            await interaction.reply({ content: "Failed to set the select menu. Please try again.", ephemeral: true });
+            await interaction.editReply({ content: "Failed to set the select menu. Please try again." });
         }
 	},
 };

--- a/commands/adminCommands/initshireselectmenu.js
+++ b/commands/adminCommands/initshireselectmenu.js
@@ -12,17 +12,18 @@ module.exports = {
             )
 		.setDefaultMemberPermissions(0),
 	async execute(interaction) {
+	        await interaction.deferReply({ flags: 64 });
 		try {
             // Call the method with the channel object directly
             let response = await admin.initShireSelect(interaction.channel, interaction.options.getString('name'));
             if (response != "Select menu set!") {
-                await interaction.reply({ content: response, ephemeral: true });
+                await interaction.editReply({ content: response });
                 return;
             }
-            await interaction.reply({ content: "Set! Select menu should appear just below this message", ephemeral: true });
+            await interaction.editReply({ content: "Set! Select menu should appear just below this message" });
         } catch (error) {
             console.error("Failed to initialize select menu:", error);
-            await interaction.reply({ content: "Failed to set the select menu. Please try again.", ephemeral: true });
+            await interaction.editReply({ content: "Failed to set the select menu. Please try again." });
         }
 	},
 };

--- a/commands/adminCommands/inittradenodeselectmenu.js
+++ b/commands/adminCommands/inittradenodeselectmenu.js
@@ -7,13 +7,14 @@ module.exports = {
 		.setDescription('Initialize a trade node select menu here')
 		.setDefaultMemberPermissions(0),
 	async execute(interaction) {
+	        await interaction.deferReply({ flags: 64 });
 		try {
             // Call the method with the channel object directly
             await admin.initTradeNodeSelect(interaction.channel);
-            await interaction.reply({ content: "Set! Select menu should appear just below this message", ephemeral: true });
+            await interaction.editReply({ content: "Set! Select menu should appear just below this message" });
         } catch (error) {
             console.error("Failed to initialize select menu:", error);
-            await interaction.reply({ content: "Failed to set the select menu. Please try again.", ephemeral: true });
+            await interaction.editReply({ content: "Failed to set the select menu. Please try again." });
         }
 	},
 };

--- a/commands/adminCommands/listplayerkingdoms.js
+++ b/commands/adminCommands/listplayerkingdoms.js
@@ -7,17 +7,18 @@ module.exports = {
         .setDescription('List all kingdoms owned by a player')
         .setDefaultMemberPermissions(0),
     async execute(interaction) {
+            await interaction.deferReply({ flags: 64 });
         try {
             let reply = await admin.listKingdoms();
             //Reply is an embed
             if (typeof(reply) == 'string') {
-                await interaction.reply({ content: reply, ephemeral: true });
+                await interaction.editReply({ content: reply });
                 return;
             }
-            await interaction.reply({ embeds: [reply] });
+            await interaction.editReply({ embeds: [reply] });
         } catch (error) {
             console.error("Failed to get player kingdoms", error);
-            await interaction.reply({ content: "An error was caught. Contact Alex.", ephemeral: true });
+            await interaction.editReply({ content: "An error was caught. Contact Alex." });
         }
     }
 };

--- a/commands/adminCommands/lore.js
+++ b/commands/adminCommands/lore.js
@@ -10,7 +10,8 @@ module.exports = {
 			.setDescription('The lore name')
 			.setRequired(true)
 		),
-	execute(interaction) {
+	async execute(interaction) {
+	        await interaction.deferReply({ flags: 64 });
 		const loreName = interaction.options.getString('lore');
 
 		(async () => {
@@ -19,9 +20,9 @@ module.exports = {
 			// If the return is a string, it's an error message
             if (typeof(returnEmbed) == 'string') {
                 // If it's a string, it's an error message, ephemeral it
-                await interaction.reply({content: returnEmbed, ephemeral: true });
+                await interaction.editReply({content: returnEmbed });
             } else {
-                await interaction.reply({ embeds: [returnEmbed] });
+                await interaction.editReply({ embeds: [returnEmbed] });
             }
 			// Call the addItem function from the Shop class
 		})()

--- a/commands/adminCommands/map.js
+++ b/commands/adminCommands/map.js
@@ -10,7 +10,8 @@ module.exports = {
 			.setDescription('The map name')
 			.setRequired(true)
 		),
-	execute(interaction) {
+	async execute(interaction) {
+	        await interaction.deferReply({ flags: 64 });
 		const mapName = interaction.options.getString('map');
 
 		(async () => {
@@ -19,9 +20,9 @@ module.exports = {
 			// If the return is a string, it's an error message
             if (typeof(returnEmbed) == 'string') {
                 // If it's a string, it's an error message, ephemeral it
-                await interaction.reply({content: returnEmbed, ephemeral: true });
+                await interaction.editReply({content: returnEmbed });
             } else {
-                await interaction.reply({ embeds: [returnEmbed] });
+                await interaction.editReply({ embeds: [returnEmbed] });
             }
 			// Call the addItem function from the Shop class
 		})()

--- a/commands/adminCommands/rank.js
+++ b/commands/adminCommands/rank.js
@@ -10,7 +10,8 @@ module.exports = {
 			.setDescription('The rank name')
 			.setRequired(true)
 		),
-	execute(interaction) {
+	async execute(interaction) {
+	        await interaction.deferReply({ flags: 64 });
 		const rankName = interaction.options.getString('rank');
 
 		(async () => {
@@ -19,9 +20,9 @@ module.exports = {
 			// If the return is a string, it's an error message
             if (typeof(returnEmbed) == 'string') {
                 // If it's a string, it's an error message, ephemeral it
-                await interaction.reply({content: returnEmbed, ephemeral: true });
+                await interaction.editReply({content: returnEmbed });
             } else {
-                await interaction.reply({ embeds: [returnEmbed] });
+                await interaction.editReply({ embeds: [returnEmbed] });
             }
 			// Call the addItem function from the Shop class
 		})()

--- a/commands/adminCommands/removeembed.js
+++ b/commands/adminCommands/removeembed.js
@@ -20,7 +20,8 @@ module.exports = {
                     {name: 'Lore', value: 'lore'},
                     {name: 'Rank', value: 'rank'},
                     {name: 'Guide', value: 'guide'})),
-	execute(interaction) {
+	async execute(interaction) {
+	        await interaction.deferReply({ flags: 64 });
 		const mapName = interaction.options.getString('embed');
 		const type = interaction.options.getString('type');
 
@@ -28,10 +29,10 @@ module.exports = {
             let returnString = await admin.removeMap(mapName, type);
 
 			if (returnString) {
-				await interaction.reply(returnString);
+				await interaction.editReply(returnString);
 			} else {
 				let capitalType = type.charAt(0).toUpperCase() + type.slice(1);
-				await interaction.reply(`${capitalType} '${mapName}' has been removed.`);
+				await interaction.editReply(`${capitalType} '${mapName}' has been removed.`);
 			}
 			// Call the addItem function from the Shop class
 		})()

--- a/commands/adminCommands/removeincome.js
+++ b/commands/adminCommands/removeincome.js
@@ -11,16 +11,17 @@ module.exports = {
             .setDescription('The income name')
             .setRequired(true)
         ),
-    execute(interaction) {
+    async execute(interaction) {
+            await interaction.deferReply({ flags: 64 });
         const itemName = interaction.options.getString('income');
 
         (async () => {
             let returnString = await shop.removeIncome(itemName);
 
 			if (returnString) {
-				await interaction.reply(returnString);
+				await interaction.editReply(returnString);
 			} else {
-				await interaction.reply(`Income '${itemName}' has been removed.`);
+				await interaction.editReply(`Income '${itemName}' has been removed.`);
 			}
             // Call the addItem function from the Shop class
         })()

--- a/commands/adminCommands/removerecipe.js
+++ b/commands/adminCommands/removerecipe.js
@@ -11,16 +11,17 @@ module.exports = {
 			.setDescription('The recipe name')
 			.setRequired(true)
 		),
-	execute(interaction) {
+	async execute(interaction) {
+	        await interaction.deferReply({ flags: 64 });
 		const itemName = interaction.options.getString('recipe');
 
 		(async () => {
             let returnString = await shop.removeRecipe(itemName);
 
 			if (returnString) {
-				await interaction.reply(returnString);
+				await interaction.editReply(returnString);
 			} else {
-				await interaction.reply(`Recipe '${itemName}' has been removed.`);
+				await interaction.editReply(`Recipe '${itemName}' has been removed.`);
 			}
 			// Call the addItem function from the Shop class
 		})()

--- a/commands/charCommands/additemstoplayer.js
+++ b/commands/charCommands/additemstoplayer.js
@@ -12,17 +12,18 @@ module.exports = {
         .addStringOption(option => option.setName('item').setDescription('The item to add').setRequired(true))
         .addIntegerOption(option => option.setName('amount').setDescription('The amount of items to add').setRequired(true)),
     async execute(interaction) {
+            await interaction.deferReply({ flags: 64 });
         const player = interaction.options.getUser('player').id;
         const item = interaction.options.getString('item');
         const amount = interaction.options.getInteger('amount');
         const response = await char.addItemToPlayer(player, item, amount);
 
         if (response == true) {
-            return interaction.reply(`Gave ${amount} ${item} to ${player}`);
+            return interaction.editReply(`Gave ${amount} ${item} to ${player}`);
         } else if (response == false || !response) {
-            return interaction.reply('Something went wrong');
+            return interaction.editReply('Something went wrong');
         } else {
-            return interaction.reply(response);
+            return interaction.editReply(response);
         }
     },
 };

--- a/commands/charCommands/additemstorole.js
+++ b/commands/charCommands/additemstorole.js
@@ -12,6 +12,7 @@ module.exports = {
         .addStringOption(option => option.setName('item').setDescription('The item to add').setRequired(true))
         .addIntegerOption(option => option.setName('amount').setDescription('The amount of items to add').setRequired(true)),
     async execute(interaction) {
+            await interaction.deferReply({ flags: 64 });
         const role = interaction.options.getRole('role');
         const item = interaction.options.getString('item');
         const amount = interaction.options.getInteger('amount');
@@ -23,12 +24,12 @@ module.exports = {
         if (typeof response == 'object') {
             if (process.env.DEBUG) console.log("here");
             if (response.length > 0) {
-                return interaction.reply("Errors on the following characters: " + response.join(", "));
+                return interaction.editReply("Errors on the following characters: " + response.join(", "));
             } else {
-                return interaction.reply(`Gave ${amount} ${item} to ${role}`);
+                return interaction.editReply(`Gave ${amount} ${item} to ${role}`);
             }
         } else {
-            return interaction.reply(response);
+            return interaction.editReply(response);
         }
     },
 };

--- a/commands/charCommands/addplayergold.js
+++ b/commands/charCommands/addplayergold.js
@@ -9,15 +9,16 @@ module.exports = {
         .addIntegerOption(option => option.setName('gold').setDescription('The amount of gold to set').setRequired(true))
         .setDefaultMemberPermissions(0),
     async execute(interaction) {
+            await interaction.deferReply({ flags: 64 });
         const player = interaction.options.getUser('player').id;
         const gold = interaction.options.getInteger('gold');
         const response = await char.addPlayerGold(player, gold);
 
         if (response) {
             //make below ephemeral
-            return interaction.reply({ content: `Added ${gold} to ${player}`, ephemeral: true });
+            return interaction.editReply({ content: `Added ${gold} to ${player}` });
         } else {
-            return interaction.reply('Something went wrong');
+            return interaction.editReply('Something went wrong');
         }
     },
 };

--- a/commands/charCommands/balance.js
+++ b/commands/charCommands/balance.js
@@ -6,10 +6,8 @@ module.exports = {
 		.setName('balance')
 		.setDescription('Show balance'),
 	async execute(interaction) {
+	        await interaction.deferReply({ flags: 64 });
                 const numericID = interaction.user.id;
-
-                await interaction.deferReply({ ephemeral: true });
-
                 const replyEmbed = await char.balance(String(numericID));
                 if (typeof(replyEmbed) == 'string') {
                         await interaction.editReply(replyEmbed);

--- a/commands/charCommands/balanceadmin.js
+++ b/commands/charCommands/balanceadmin.js
@@ -8,14 +8,15 @@ module.exports = {
         .addUserOption(option => option.setName('player').setDescription('The player to show the balance of').setRequired(true))
         .setDefaultMemberPermissions(0),
         async execute(interaction) {
+                await interaction.deferReply({ flags: 64 });
                 const charID = interaction.options.getUser('player').id;
 
 		(async () => {
             let replyEmbed = await char.balance(charID);
             if (typeof(replyEmbed) == 'string') {
-                await interaction.reply(replyEmbed);
+                await interaction.editReply(replyEmbed);
             } else {
-                await interaction.reply({ embeds: [replyEmbed] });
+                await interaction.editReply({ embeds: [replyEmbed] });
             }
 		})()
 	},

--- a/commands/charCommands/balanceall.js
+++ b/commands/charCommands/balanceall.js
@@ -6,15 +6,16 @@ module.exports = {
 		.setName('balanceall')
 		.setDescription('Show balance of all players')
         .setDefaultMemberPermissions(0),
-	execute(interaction) {
+	async execute(interaction) {
+	        await interaction.deferReply({ flags: 64 });
 
 		(async () => {
             let [replyEmbed, replyRows] = await char.balanceAll(1);
             if (typeof(replyEmbed) == 'string') {
-                await interaction.reply(replyEmbed);
+                await interaction.editReply(replyEmbed);
             } else {
                 //Has action rows
-                await interaction.reply({ embeds: [replyEmbed], components: replyRows});
+                await interaction.editReply({ embeds: [replyEmbed], components: replyRows});
             }
 		})()
 	},

--- a/commands/charCommands/bank.js
+++ b/commands/charCommands/bank.js
@@ -6,8 +6,8 @@ module.exports = {
 		.setName('bank')
 		.setDescription('Show bank'),
 	async execute(interaction) {
+	        await interaction.deferReply({ flags: 64 });
                 const numericID = interaction.user.id;
-                await interaction.deferReply({ ephemeral: true });
                 const replyEmbed = await char.bank(String(numericID));
                 if (typeof(replyEmbed) == 'string') {
                         await interaction.editReply(replyEmbed);

--- a/commands/charCommands/changeplayerstats.js
+++ b/commands/charCommands/changeplayerstats.js
@@ -16,6 +16,7 @@ module.exports = {
         .addIntegerOption(option => option.setName('value').setDescription('The value to change stat by').setRequired(true))
         .setDefaultMemberPermissions(0),
     async execute(interaction) {
+            await interaction.deferReply({ flags: 64 });
         const player = interaction.options.getUser('player').id;
         const stat = interaction.options.getString('stat');
         const value = interaction.options.getInteger('value');
@@ -24,11 +25,11 @@ module.exports = {
 
         if (response) {
             if (response == "Error: Player not found") {
-                return interaction.reply(`Player not found`);
+                return interaction.editReply(`Player not found`);
             }
-            return interaction.reply(`Changed ${response} by ${value} for ${player}`);
+            return interaction.editReply(`Changed ${response} by ${value} for ${player}`);
         } else {
-            return interaction.reply('Something went wrong');
+            return interaction.editReply('Something went wrong');
         }
     },
 };

--- a/commands/charCommands/char.js
+++ b/commands/charCommands/char.js
@@ -5,15 +5,16 @@ module.exports = {
 	data: new SlashCommandBuilder()
 		.setName('char')
 		.setDescription('Show player character'),
-	execute(interaction) {
+	async execute(interaction) {
+	        await interaction.deferReply({ flags: 64 });
                 const numericID = interaction.user.id;
 
                 (async () => {
             let replyEmbed = await char.char(String(numericID));
             if (typeof(replyEmbed) == 'string') {
-                await interaction.reply(replyEmbed);
+                await interaction.editReply(replyEmbed);
             } else {
-                await interaction.reply({ embeds: [replyEmbed] });
+                await interaction.editReply({ embeds: [replyEmbed] });
             }
 		})()
 	},

--- a/commands/charCommands/charadmin.js
+++ b/commands/charCommands/charadmin.js
@@ -12,14 +12,15 @@ module.exports = {
 				.setRequired(true)
 		),
         async execute(interaction) {
+                await interaction.deferReply({ flags: 64 });
                 const charID = interaction.options.getUser('character').id;
 
 		(async () => {
             let replyEmbed = await char.char(charID);
             if (typeof(replyEmbed) == 'string') {
-                await interaction.reply(replyEmbed);
+                await interaction.editReply(replyEmbed);
             } else {
-                await interaction.reply({ embeds: [replyEmbed] });
+                await interaction.editReply({ embeds: [replyEmbed] });
             }
 		})()
 	},

--- a/commands/charCommands/craft.js
+++ b/commands/charCommands/craft.js
@@ -10,15 +10,16 @@ module.exports = {
 			.setDescription('The recipe name')
 			.setRequired(true)
 		),
-	execute(interaction) {
+	async execute(interaction) {
+	        await interaction.deferReply({ flags: 64 });
 		const recipe = interaction.options.getString('recipe');
 
 		(async () => {
             let reply = await char.craft(interaction.user, recipe, interaction.guild)
             if (typeof(reply) == 'string') {
-                await interaction.reply(reply);
+                await interaction.editReply(reply);
             } else {
-                await interaction.reply({ embeds: [reply] });
+                await interaction.editReply({ embeds: [reply] });
             }
 			// Call the useItem function from the Shop class
 		})()

--- a/commands/charCommands/crafting.js
+++ b/commands/charCommands/crafting.js
@@ -6,14 +6,15 @@ module.exports = {
         .setName('crafting')
         .setDescription('View crafting cooldowns'),
     async execute(interaction) {
+            await interaction.deferReply({ flags: 64 });
         try {
             const numericID = interaction.user.id;
             var replyEmbed = await char.craftingCooldowns(String(numericID));
-            await interaction.reply(({ embeds: [replyEmbed] }));
+            await interaction.editReply(({ embeds: [replyEmbed] }));
         } catch (error) {
             if (process.env.DEBUG) console.log(error);
             if (replyEmbed) {
-                await interaction.reply(replyEmbed);
+                await interaction.editReply(replyEmbed);
             }
         }
     },

--- a/commands/charCommands/deposit.js
+++ b/commands/charCommands/deposit.js
@@ -9,16 +9,17 @@ module.exports = {
             option.setName('quantity')
                 .setDescription('Quantity to deposit')
                 .setRequired(true)),
-	execute(interaction) {
+	async execute(interaction) {
+	        await interaction.deferReply({ flags: 64 });
                 const numericID = interaction.user.id;
         const quantity = interaction.options.getInteger('quantity');
 
                 (async () => {
             let replyEmbed = await char.deposit(String(numericID), quantity);
             if (typeof(replyEmbed) == 'string') {
-                await interaction.reply(replyEmbed);
+                await interaction.editReply(replyEmbed);
             } else {
-                await interaction.reply("Deposited " + quantity + " gold to bank");
+                await interaction.editReply("Deposited " + quantity + " gold to bank");
             }
 		})()
 	},

--- a/commands/charCommands/givegold.js
+++ b/commands/charCommands/givegold.js
@@ -11,17 +11,18 @@ module.exports = {
         .addUserOption(option => option.setName('player').setDescription('The player to give gold to').setRequired(true))
         .addIntegerOption(option => option.setName('amount').setDescription('The amount of gold to give').setRequired(true)),
     async execute(interaction) {
+            await interaction.deferReply({ flags: 64 });
         const numericID = interaction.user.id;
         const player = interaction.options.getUser('player').id;
         const amount = interaction.options.getInteger('amount');
         const response = await char.giveGoldToPlayer(String(numericID), String(player), amount);
 
         if (response == true) {
-            return interaction.reply(`Gave ${clientManager.getEmoji("Gold")} ${amount} to ${player}`);
+            return interaction.editReply(`Gave ${clientManager.getEmoji("Gold")} ${amount} to ${player}`);
         } else if (response == false || !response) {
-            return interaction.reply('Something went wrong');
+            return interaction.editReply('Something went wrong');
         } else {
-            return interaction.reply(response);
+            return interaction.editReply(response);
         }
     },
 };

--- a/commands/charCommands/giveitem.js
+++ b/commands/charCommands/giveitem.js
@@ -11,6 +11,7 @@ module.exports = {
         .addStringOption(option => option.setName('item').setDescription('The item to give').setRequired(true))
         .addIntegerOption(option => option.setName('amount').setDescription('The amount of items to give').setRequired(false)),
     async execute(interaction) {
+            await interaction.deferReply({ flags: 64 });
         const numericID = interaction.user.id;
         const player = interaction.options.getUser('player').id;
         const item = interaction.options.getString('item');
@@ -21,11 +22,11 @@ module.exports = {
         const response = await char.giveItemToPlayer(String(numericID), String(player), item, amount);
 
         if (response == true) {
-            return interaction.reply(`Gave ${amount} ${item} to ${player}`);
+            return interaction.editReply(`Gave ${amount} ${item} to ${player}`);
         } else if (response == false || !response) {
-            return interaction.reply('Something went wrong');
+            return interaction.editReply('Something went wrong');
         } else {
-            return interaction.reply(response);
+            return interaction.editReply(response);
         }
     },
 };

--- a/commands/charCommands/grab.js
+++ b/commands/charCommands/grab.js
@@ -13,7 +13,8 @@ module.exports = {
             option.setName('quantity')
                 .setDescription('Quantity to grab')
                 .setRequired(true)),
-	execute(interaction) {
+	async execute(interaction) {
+	        await interaction.deferReply({ flags: 64 });
                 const numericID = interaction.user.id;
         const item = interaction.options.getString('item');
         const quantity = interaction.options.getInteger('quantity');
@@ -21,9 +22,9 @@ module.exports = {
 		(async () => {
             let replyEmbed = await char.grab(String(numericID), item, quantity);
             if (typeof(replyEmbed) == 'string') {
-                await interaction.reply(replyEmbed);
+                await interaction.editReply(replyEmbed);
             } else {
-                await interaction.reply("Grabbed " + quantity + " " + item + " from storage");
+                await interaction.editReply("Grabbed " + quantity + " " + item + " from storage");
             }
 		})()
 	},

--- a/commands/charCommands/incomes.js
+++ b/commands/charCommands/incomes.js
@@ -6,15 +6,13 @@ module.exports = {
 		.setName('incomes')
 		.setDescription('Collect your daily incomes'),
         async execute(interaction) {
+                await interaction.deferReply({ flags: 64 });
                 const numericID = interaction.user.id;
                 const roles = interaction.member.roles.cache;
-
-                await interaction.deferReply({ ephemeral: true });
-
                 const [replyEmbed, replyString] = await char.incomes(String(numericID), roles);
                 await interaction.editReply({ embeds: [replyEmbed] });
                 if (replyString) {
-                        await interaction.followUp({ content: replyString, ephemeral: true });
+                        await interaction.followUp({ content: replyString });
                 }
         },
 };

--- a/commands/charCommands/me.js
+++ b/commands/charCommands/me.js
@@ -5,15 +5,16 @@ module.exports = {
 	data: new SlashCommandBuilder()
 		.setName('me')
 		.setDescription('Show player character- only RP aspects'),
-	execute(interaction) {
+	async execute(interaction) {
+	        await interaction.deferReply({ flags: 64 });
                 const numericID = interaction.user.id;
 
                 (async () => {
             let replyEmbed = await char.me(String(numericID));
             if (typeof(replyEmbed) == 'string') {
-                await interaction.reply(replyEmbed);
+                await interaction.editReply(replyEmbed);
             } else {
-                await interaction.reply({ embeds: [replyEmbed] });
+                await interaction.editReply({ embeds: [replyEmbed] });
             }
                 })()
         },

--- a/commands/charCommands/say.js
+++ b/commands/charCommands/say.js
@@ -10,16 +10,17 @@ module.exports = {
 			.setDescription('The message to send')
 			.setRequired(true)
 		),
-	execute(interaction) {
+	async execute(interaction) {
+	        await interaction.deferReply({ flags: 64 });
         const message = interaction.options.getString('message');
         const numericID = interaction.user.id;
 
                 (async () => {
             let reply = await char.say(String(numericID), message, interaction.channel)
             if (typeof(reply) == 'string') {
-                await interaction.reply({ content: reply, ephemeral: true });
+                await interaction.editReply({ content: reply });
             } else {
-                await interaction.reply({ embeds: [reply] });
+                await interaction.editReply({ embeds: [reply] });
             }
             // Call the useItem function from the Shop class
         })()

--- a/commands/charCommands/setavatar.js
+++ b/commands/charCommands/setavatar.js
@@ -10,13 +10,14 @@ module.exports = {
 			.setDescription('URL of your avatar')
 			.setRequired(true)
 		),
-	execute(interaction) {
+	async execute(interaction) {
+	        await interaction.deferReply({ flags: 64 });
                 const avatarURL = interaction.options.getString('avatarurl');
                 const numericID = interaction.user.id;
 
                 (async () => {
                         let replyString = await char.setAvatar(avatarURL, String(numericID))
-                        await interaction.reply(replyString);
+                        await interaction.editReply(replyString);
                 })()
         },
 };

--- a/commands/charCommands/setplayergold.js
+++ b/commands/charCommands/setplayergold.js
@@ -9,14 +9,15 @@ module.exports = {
         .addIntegerOption(option => option.setName('gold').setDescription('The amount of gold to set').setRequired(true))
         .setDefaultMemberPermissions(0),
     async execute(interaction) {
+            await interaction.deferReply({ flags: 64 });
         const player = interaction.options.getUser('player').id;
         const gold = interaction.options.getInteger('gold');
         const response = await char.setPlayerGold(player, gold);
 
         if (response) {
-            return interaction.reply(`Set gold to ${gold} for ${player}`);
+            return interaction.editReply(`Set gold to ${gold} for ${player}`);
         } else {
-            return interaction.reply('Something went wrong');
+            return interaction.editReply('Something went wrong');
         }
     },
 };

--- a/commands/charCommands/stats.js
+++ b/commands/charCommands/stats.js
@@ -5,15 +5,16 @@ module.exports = {
 	data: new SlashCommandBuilder()
 		.setName('stats')
 		.setDescription('Show player stats'),
-	execute(interaction) {
+	async execute(interaction) {
+	        await interaction.deferReply({ flags: 64 });
                 const numericID = interaction.user.id;
 
                 (async () => {
             let replyEmbed = await char.stats(String(numericID));
             if (typeof(replyEmbed) == 'string') {
-                await interaction.reply({ content: replyEmbed, ephemeral: true });
+                await interaction.editReply({ content: replyEmbed });
             } else {
-                await interaction.reply({ embeds: [replyEmbed], ephemeral: true });
+                await interaction.editReply({ embeds: [replyEmbed] });
             }
                 })()
         },

--- a/commands/charCommands/storage.js
+++ b/commands/charCommands/storage.js
@@ -6,8 +6,8 @@ module.exports = {
                 .setName('storage')
                 .setDescription('Show your storage'),
         async execute(interaction) {
+                await interaction.deferReply({ flags: 64 });
                 const numericID = interaction.user.id;
-                await interaction.deferReply({ ephemeral: true });
                 const replyEmbed = await shop.storage(String(numericID));
                 await interaction.editReply({ embeds: [replyEmbed] });
         },

--- a/commands/charCommands/store.js
+++ b/commands/charCommands/store.js
@@ -13,7 +13,8 @@ module.exports = {
             option.setName('quantity')
                 .setDescription('Quantity to store')
                 .setRequired(true)),
-	execute(interaction) {
+	async execute(interaction) {
+	        await interaction.deferReply({ flags: 64 });
                 const numericID = interaction.user.id;
         const item = interaction.options.getString('item');
         const quantity = interaction.options.getInteger('quantity');
@@ -21,9 +22,9 @@ module.exports = {
 		(async () => {
             let replyEmbed = await char.store(String(numericID), item, quantity);
             if (typeof(replyEmbed) == 'string') {
-                await interaction.reply(replyEmbed);
+                await interaction.editReply(replyEmbed);
             } else {
-                await interaction.reply("Stored " + quantity + " " + item + " to storage");
+                await interaction.editReply("Stored " + quantity + " " + item + " to storage");
             }
 		})()
 	},

--- a/commands/charCommands/takeitemsfromplayer.js
+++ b/commands/charCommands/takeitemsfromplayer.js
@@ -12,17 +12,18 @@ module.exports = {
         .addStringOption(option => option.setName('item').setDescription('The item to take').setRequired(true))
         .addIntegerOption(option => option.setName('amount').setDescription('The amount of items to take').setRequired(true)),
     async execute(interaction) {
+            await interaction.deferReply({ flags: 64 });
         const player = interaction.options.getUser('player').id;
         const item = interaction.options.getString('item');
         const amount = interaction.options.getInteger('amount');
         const response = await char.addItemToPlayer(player, item, -amount);
 
         if (response == true) {
-            return interaction.reply(`Took ${amount} ${item} from ${player}`);
+            return interaction.editReply(`Took ${amount} ${item} from ${player}`);
         } else if (response == false || !response) {
-            return interaction.reply('Something went wrong');
+            return interaction.editReply('Something went wrong');
         } else {
-            return interaction.reply(response);
+            return interaction.editReply(response);
         }
     },
 };

--- a/commands/charCommands/transfergold.js
+++ b/commands/charCommands/transfergold.js
@@ -13,17 +13,18 @@ module.exports = {
         .addUserOption(option => option.setName('playergetting').setDescription('The player to give gold to').setRequired(true))
         .addIntegerOption(option => option.setName('amount').setDescription('The amount of gold to give').setRequired(true)),
     async execute(interaction) {
+            await interaction.deferReply({ flags: 64 });
         const playerGiving = interaction.options.getUser('playergiving').id;
         const player = interaction.options.getUser('playergetting').id;
         const amount = interaction.options.getInteger('amount');
         const response = await char.giveGoldToPlayer(playerGiving, player, amount);
 
         if (response == true) {
-            return interaction.reply(`Gave ${clientManager.getEmoji("Gold")} ${amount} to ${player}`);
+            return interaction.editReply(`Gave ${clientManager.getEmoji("Gold")} ${amount} to ${player}`);
         } else if (response == false || !response) {
-            return interaction.reply('Something went wrong');
+            return interaction.editReply('Something went wrong');
         } else {
-            return interaction.reply(response);
+            return interaction.editReply(response);
         }
     },
 };

--- a/commands/charCommands/useitem.js
+++ b/commands/charCommands/useitem.js
@@ -15,7 +15,8 @@ module.exports = {
 			.setDescription('How many do you want to buy (Leave blank for 1)')
 			.setRequired(false)
 		),
-	execute(interaction) {
+	async execute(interaction) {
+	        await interaction.deferReply({ flags: 64 });
                 const itemName = interaction.options.getString('itemname');
         const numberItems = interaction.options.getInteger('numbertouse');
         const numericID = interaction.user.id;
@@ -23,9 +24,9 @@ module.exports = {
                 (async () => {
             let reply = await char.useItem(itemName, String(numericID), numberItems)
             if (typeof(reply) == 'string') {
-                await interaction.reply(reply);
+                await interaction.editReply(reply);
             } else {
-                await interaction.reply({ embeds: [reply] });
+                await interaction.editReply({ embeds: [reply] });
             }
                         // Call the useItem function from the Shop class
                 })()

--- a/commands/charCommands/warn.js
+++ b/commands/charCommands/warn.js
@@ -10,9 +10,10 @@ module.exports = {
         .setDefaultMemberPermissions(0)
         .addUserOption(option => option.setName('player').setDescription('The player to warn').setRequired(true)),
     async execute(interaction) {
+            await interaction.deferReply({ flags: 64 });
         const player = interaction.options.getUser('player').id;
         const response = await char.warn(player);
 
-        return interaction.reply(response);
+        return interaction.editReply(response);
     },
 };

--- a/commands/charCommands/warnings.js
+++ b/commands/charCommands/warnings.js
@@ -9,10 +9,11 @@ module.exports = {
         .setDescription('Check warnings')
         .addUserOption(option => option.setName('player').setDescription('The player to check warnings of').setRequired(false)),
     async execute(interaction) {
+            await interaction.deferReply({ flags: 64 });
         const numericID = interaction.user.id;
         const player = interaction.options.getUser('player')?.id || numericID;
         const response = await char.checkWarns(String(player));
 
-        return interaction.reply(response);
+        return interaction.editReply(response);
     },
 };

--- a/commands/charCommands/withdraw.js
+++ b/commands/charCommands/withdraw.js
@@ -9,16 +9,17 @@ module.exports = {
             option.setName('quantity')
                 .setDescription('Quantity to withdraw')
                 .setRequired(true)),
-	execute(interaction) {
+	async execute(interaction) {
+	        await interaction.deferReply({ flags: 64 });
                 const numericID = interaction.user.id;
         const quantity = interaction.options.getInteger('quantity');
 
                 (async () => {
             let replyEmbed = await char.withdraw(String(numericID), quantity);
             if (typeof(replyEmbed) == 'string') {
-                await interaction.reply(replyEmbed);
+                await interaction.editReply(replyEmbed);
             } else {
-                await interaction.reply("Withdrew " + quantity + " gold from bank");
+                await interaction.editReply("Withdrew " + quantity + " gold from bank");
             }
 		})()
 	},

--- a/commands/helpCommands/allrecipes.js
+++ b/commands/helpCommands/allrecipes.js
@@ -6,14 +6,15 @@ module.exports = {
 		.setName('allrecipes')
 		.setDescription('List all recipes'),
 	async execute(interaction) {
+	        await interaction.deferReply({ flags: 64 });
         reply = await shop.recipesEmbed(!interaction.member.permissions.has(PermissionFlagsBits.Administrator), 1);
         if (typeof(reply) == 'string') {
-            await interaction.reply(reply);
+            await interaction.editReply(reply);
             return;
         }
         else {
             let [embed, rows] = reply;
-            await interaction.reply({ embeds: [reply[0]], components: [reply[1]]});
+            await interaction.editReply({ embeds: [reply[0]], components: [reply[1]]});
         }
 	},
 };

--- a/commands/helpCommands/help.js
+++ b/commands/helpCommands/help.js
@@ -10,25 +10,26 @@ module.exports = {
                 .setDescription('The command you want helped with')
                 .setRequired(false)),
 	async execute(interaction) {
+	        await interaction.deferReply({ flags: 64 });
 		try {
             let command = interaction.options.getString('command');
 
             if (command == null) {
                 let [embed, rows] = await admin.generalHelpMenu(1, false);
-                await interaction.reply({ embeds: [embed], components: rows});
+                await interaction.editReply({ embeds: [embed], components: rows});
                 return;
             } else {
                 let replyEmbed = await admin.commandHelp(command);
                 if (replyEmbed == null) {
-                    await interaction.reply({ content: "Command not found: if this command exists, contact Alex to add it to the help list", ephemeral: true });
+                    await interaction.editReply({ content: "Command not found: if this command exists, contact Alex to add it to the help list" });
                 } else {
-                    await interaction.reply({ embeds: [replyEmbed] });
+                    await interaction.editReply({ embeds: [replyEmbed] });
                 }
                 return;
             }
         } catch (error) {
             console.error("Failed to help:", error);
-            await interaction.reply({ content: "Failed to help. Please try again.", ephemeral: true });
+            await interaction.editReply({ content: "Failed to help. Please try again." });
         }
 	},
 };

--- a/commands/helpCommands/helpadmin.js
+++ b/commands/helpCommands/helpadmin.js
@@ -10,25 +10,26 @@ module.exports = {
                 .setDescription('The command you want helped with')
                 .setRequired(false)),
 	async execute(interaction) {
+	        await interaction.deferReply({ flags: 64 });
 		try {
             let command = interaction.options.getString('command');
 
             if (command == null) {
                 let [embed, rows] = await admin.generalHelpMenu(1, true);
-                await interaction.reply({ embeds: [embed], components: rows});
+                await interaction.editReply({ embeds: [embed], components: rows});
                 return;
             } else {
                 let replyEmbed = admin.commandHelp(command);
                 if (replyEmbed == null) {
-                    await interaction.reply({ content: "Command not found: if this command exists, contact Alex to add it to the help list", ephemeral: true });
+                    await interaction.editReply({ content: "Command not found: if this command exists, contact Alex to add it to the help list" });
                 } else {
-                    await interaction.reply({ embeds: [replyEmbed] });
+                    await interaction.editReply({ embeds: [replyEmbed] });
                 }
                 return;
             }
         } catch (error) {
             console.error("Failed to help:", error);
-            await interaction.reply({ content: "Failed to help. Please try again.", ephemeral: true });
+            await interaction.editReply({ content: "Failed to help. Please try again." });
         }
 	},
 };

--- a/commands/helpCommands/inspectrecipe.js
+++ b/commands/helpCommands/inspectrecipe.js
@@ -11,15 +11,16 @@ module.exports = {
                 .setRequired(true)
         ),
     async execute(interaction) {
+            await interaction.deferReply({ flags: 64 });
         const recipe = interaction.options.getString('recipe');
 
         (async () => {
             let reply = await shop.inspectRecipe(recipe)
             if (typeof(reply) == 'string') {
                 // Ephemeral reply
-                await interaction.reply({content: reply, ephemeral: true });
+                await interaction.editReply({content: reply });
             } else {
-                await interaction.reply({ embeds: [reply], ephemeral: true });
+                await interaction.editReply({ embeds: [reply] });
             }
             // Call the useItem function from the Shop class
         })()

--- a/commands/raid.js
+++ b/commands/raid.js
@@ -25,8 +25,7 @@ module.exports = {
     .setName('raid')
     .setDescription('Launch a raid against one of the available targets'),
   async execute(interaction) {
-    await interaction.deferReply({ flags: 64 });
-
+          await interaction.deferReply({ flags: 64 });
     const numericID = interaction.user.id;
     const charId = String(numericID);
 

--- a/commands/salesCommands/buysale.js
+++ b/commands/salesCommands/buysale.js
@@ -13,14 +13,15 @@ module.exports = {
                 .setRequired(true)
         ),
     async execute(interaction) {
+            await interaction.deferReply({ flags: 64 });
         const saleID = interaction.options.getString('saleid');
         const numericID = interaction.user.id;
         let replyString = await marketplace.buySale(saleID, String(numericID));
         //if embed, display embed, otherwise display string
         if (typeof (replyString) == 'string') {
-            await interaction.reply(replyString);
+            await interaction.editReply(replyString);
         } else {
-            await interaction.reply({ embeds: [replyString] });
+            await interaction.editReply({ embeds: [replyString] });
         }
     },
 };

--- a/commands/salesCommands/inspectsale.js
+++ b/commands/salesCommands/inspectsale.js
@@ -13,13 +13,14 @@ module.exports = {
                 .setRequired(true)
         ),
     async execute(interaction) {
+            await interaction.deferReply({ flags: 64 });
         const saleID = interaction.options.getString('saleid');
         let replyString = await marketplace.inspectSale(saleID);
         //if embed, display embed, otherwise display string
         if (typeof (replyString) == 'string') {
-            await interaction.reply({ content: replyString, ephemeral: true });
+            await interaction.editReply({ content: replyString });
         } else {
-            await interaction.reply({ embeds: [replyString], ephemeral: true });
+            await interaction.editReply({ embeds: [replyString] });
         }
     },
 };

--- a/commands/salesCommands/sales.js
+++ b/commands/salesCommands/sales.js
@@ -6,7 +6,7 @@ module.exports = {
         .setName('sales')
         .setDescription('List sales'),
     async execute(interaction) {
-        await interaction.deferReply({ ephemeral: true });
+            await interaction.deferReply({ flags: 64 });
         const [embed, rows] = await marketplace.createSalesEmbed(1, interaction);
         await interaction.editReply({ embeds: [embed], components: rows });
     },

--- a/commands/salesCommands/sell.js
+++ b/commands/salesCommands/sell.js
@@ -22,6 +22,7 @@ module.exports = {
                 .setRequired(true)
         ),
     async execute(interaction) {
+            await interaction.deferReply({ flags: 64 });
         const itemName = interaction.options.getString('itemname');
         const quantity = interaction.options.getInteger('quantity');
         const price = interaction.options.getInteger('price');
@@ -30,9 +31,9 @@ module.exports = {
         (async () => {
             let reply = await marketplace.postSale(quantity, itemName, price, String(numericID));
             if (typeof (reply) == 'string') {
-                await interaction.reply(reply);
+                await interaction.editReply(reply);
             } else {
-                await interaction.reply({ embeds: [reply] });
+                await interaction.editReply({ embeds: [reply] });
             }
         })()
     }

--- a/commands/salesCommands/showsales.js
+++ b/commands/salesCommands/showsales.js
@@ -18,6 +18,7 @@ module.exports = {
                 .setRequired(false)
         ),
     async execute(interaction) {
+            await interaction.deferReply({ flags: 64 });
         let seller = interaction.options.getUser('player');
         let page = interaction.options.getInteger('page');
         if (process.env.DEBUG) console.log(seller);
@@ -33,9 +34,9 @@ module.exports = {
         let replyString = await marketplace.showSales(sellerID, page);
         //if embed, display embed, otherwise display string
         if (typeof (replyString) == 'string') {
-            await interaction.reply(replyString);
+            await interaction.editReply(replyString);
         } else {
-            await interaction.reply({ embeds: [replyString] });
+            await interaction.editReply({ embeds: [replyString] });
         }
     },
 };

--- a/commands/shopCommands/additem.js
+++ b/commands/shopCommands/additem.js
@@ -13,6 +13,7 @@ module.exports = {
 		.addStringOption(option => option.setName('itemcategory').setDescription('The category of the item').setRequired(true))
 		.addStringOption(option => option.setName('itemprice').setDescription('The price of the item').setRequired(false)),
 	async execute(interaction) {
+	        await interaction.deferReply({ flags: 64 });
 		// Call the addItem function from the Shop class with the collected information
 		if (parseInt(interaction.options.getString('itemprice'))) {
 			shop.addItem(
@@ -38,6 +39,6 @@ module.exports = {
 		}
 
 		// Show the modal to the user
-		await interaction.reply(`Item '${interaction.options.getString('itemname')}' has been added to the item list. Edit it using /edititemmenu. Give it a price to add to shop.`);
+		await interaction.editReply(`Item '${interaction.options.getString('itemname')}' has been added to the item list. Edit it using /edititemmenu. Give it a price to add to shop.`);
 	},
 };

--- a/commands/shopCommands/addrecipe.js
+++ b/commands/shopCommands/addrecipe.js
@@ -12,6 +12,7 @@ module.exports = {
             .setDescription('The name of the recipe')
             .setRequired(false)),
     async execute(interaction) {
+            await interaction.deferReply({ flags: 64 });
         let recipeName = interaction.options.getString('recipename');
         if (!recipeName) {
             recipeName = 'New Recipe';
@@ -20,7 +21,7 @@ module.exports = {
         recipeName = await shop.addRecipe(recipeName);
         
         // Respons with an ephemeral message saying that recipe should appear below
-        await interaction.reply({ content: 'Edit recipe menu should appear below', ephemeral: true });
+        await interaction.editReply({ content: 'Edit recipe menu should appear below' });
 
         // Show the edit recipe menu
         const numericID = interaction.user.id;

--- a/commands/shopCommands/allitems.js
+++ b/commands/shopCommands/allitems.js
@@ -7,10 +7,11 @@ module.exports = {
 		.setDefaultMemberPermissions(0)
 		.setDescription('List all items'),
 	async execute(interaction) {
+	        await interaction.deferReply({ flags: 64 });
                 // const itemListString = await shop.shop();
-                // await interaction.reply(itemListString);
+                // await interaction.editReply(itemListString);
 		let [embed, rows] = await shop.createAllItemsEmbed(1, interaction);
                 if (process.env.DEBUG) console.log(rows);
-		await interaction.reply({ embeds: [embed], components: rows});
+		await interaction.editReply({ embeds: [embed], components: rows});
 	},
 };

--- a/commands/shopCommands/buyitem.js
+++ b/commands/shopCommands/buyitem.js
@@ -15,14 +15,15 @@ module.exports = {
 			.setDescription('The item name')
 			.setRequired(true)
 		),
-	execute(interaction) {
+	async execute(interaction) {
+	        await interaction.deferReply({ flags: 64 });
         const itemName = interaction.options.getString('itemname');
         const numberItems = interaction.options.getInteger('numbertobuy');
         const numericID = interaction.user.id;
 
                 (async () => {
             let reply = await shop.buyItem(itemName, String(numericID), numberItems, interaction.channelId)
-            interaction.reply(reply);
+            interaction.editReply(reply);
                         // Call the addItem function from the Shop class
                 })()
         },

--- a/commands/shopCommands/edititemfield.js
+++ b/commands/shopCommands/edititemfield.js
@@ -18,12 +18,13 @@ module.exports = {
                 .setRequired(false)
         ),
     async execute(interaction) {
+            await interaction.deferReply({ flags: 64 });
         const fieldNumber = interaction.options.getInteger('fieldnumber');
         const newValue = interaction.options.getString('newvalue');
 
         if (process.env.DEBUG) console.log('new value: ' + newValue);
         const numericID = interaction.user.id;
         let reply = await shop.editItemField(String(numericID), fieldNumber, newValue);
-        await interaction.reply(reply);
+        await interaction.editReply(reply);
     }
 };

--- a/commands/shopCommands/edititemmenu.js
+++ b/commands/shopCommands/edititemmenu.js
@@ -12,10 +12,8 @@ module.exports = {
                 .setRequired(true)
         ),
     async execute(interaction) {
+            await interaction.deferReply({ flags: 64 });
         const itemName = interaction.options.getString('itemname');
-        await interaction.deferReply();
-
-        // shop.editItemMenu returns an array with the first element being the replyEmbed and the second element being the rows
         const numericID = interaction.user.id;
         const reply = await shop.editItemMenu(itemName, 1, String(numericID));
         if (typeof reply === 'string') {

--- a/commands/shopCommands/editrecipefield.js
+++ b/commands/shopCommands/editrecipefield.js
@@ -18,10 +18,11 @@ module.exports = {
                 .setRequired(false)
         ),
     async execute(interaction) {
+            await interaction.deferReply({ flags: 64 });
         const fieldNumber = interaction.options.getInteger('fieldnumber');
         const newValue = interaction.options.getString('newvalue');
         const numericID = interaction.user.id;
         let reply = await shop.editRecipeField(String(numericID), fieldNumber, newValue);
-        await interaction.reply(reply);
+        await interaction.editReply(reply);
     }
 };

--- a/commands/shopCommands/editrecipemenu.js
+++ b/commands/shopCommands/editrecipemenu.js
@@ -11,7 +11,8 @@ module.exports = {
 			.setDescription('The recipe name')
 			.setRequired(true)
 		),
-	execute(interaction) {
+	async execute(interaction) {
+	        await interaction.deferReply({ flags: 64 });
                 const recipeName = interaction.options.getString('recipename');
 
                 (async () => {
@@ -19,9 +20,9 @@ module.exports = {
                         const numericID = interaction.user.id;
                         let reply = await shop.editRecipeMenu(recipeName, String(numericID));
                         if (typeof(reply) == 'string') {
-                            await interaction.reply(reply);
+                            await interaction.editReply(reply);
                         } else {
-                            await interaction.reply({ embeds: [reply]});
+                            await interaction.editReply({ embeds: [reply]});
                         }
 		})()
 	},

--- a/commands/shopCommands/inspect.js
+++ b/commands/shopCommands/inspect.js
@@ -10,15 +10,16 @@ module.exports = {
 			.setDescription('The item name')
 			.setRequired(true)
 		),
-	execute(interaction) {
+	async execute(interaction) {
+	        await interaction.deferReply({ flags: 64 });
 		const itemName = interaction.options.getString('itemname');
 
 		(async () => {
             let replyEmbed = await shop.inspect(itemName);
             if (typeof(replyEmbed) == 'string') {
-                await interaction.reply({content: replyEmbed, ephemeral: true });
+                await interaction.editReply({content: replyEmbed });
             } else {
-                await interaction.reply({ embeds: [replyEmbed], ephemeral: true });
+                await interaction.editReply({ embeds: [replyEmbed] });
             }
                 })()
         },

--- a/commands/shopCommands/inventory.js
+++ b/commands/shopCommands/inventory.js
@@ -6,9 +6,9 @@ module.exports = {
                 .setName('inventory')
                 .setDescription('Displays your inventory'),
         async execute(interaction) {
+                await interaction.deferReply({ flags: 64 });
                 const numericID = interaction.user.id;
                 // Immediately defer the reply so Discord doesn’t time out
-                await interaction.deferReply({ flags: 64 }); // 64 = Ephemeral
                 const inventoryEmbed = await shop.createInventoryEmbed(String(numericID));
                 // Edit the deferred reply with the embed
                 await interaction.editReply({ embeds: [inventoryEmbed] });

--- a/commands/shopCommands/inventoryadmin.js
+++ b/commands/shopCommands/inventoryadmin.js
@@ -12,8 +12,9 @@ module.exports = {
 				.setRequired(true)
 		),
 	async execute(interaction) {
+	        await interaction.deferReply({ flags: 64 });
         const userID = interaction.options.getUser('user').id;
 		var replyEmbed = await shop.createInventoryEmbed(userID);
-		await interaction.reply(({ embeds: [replyEmbed] }));
+		await interaction.editReply(({ embeds: [replyEmbed] }));
 	},
 };

--- a/commands/shopCommands/removeitem.js
+++ b/commands/shopCommands/removeitem.js
@@ -11,16 +11,17 @@ module.exports = {
 			.setDescription('The item name')
 			.setRequired(true)
 		),
-	execute(interaction) {
+	async execute(interaction) {
+	        await interaction.deferReply({ flags: 64 });
 		const itemName = interaction.options.getString('itemname');
 
 		(async () => {
 			let returnString = await shop.removeItem(itemName);
 
 			if (returnString) {
-				await interaction.reply(returnString);
+				await interaction.editReply(returnString);
 			} else {
-				await interaction.reply(`Item '${itemName}' has been removed from the shop.`);
+				await interaction.editReply(`Item '${itemName}' has been removed from the shop.`);
 			}
 			// Call the addItem function from the Shop class
 		})()

--- a/commands/shopCommands/renamecategory.js
+++ b/commands/shopCommands/renamecategory.js
@@ -16,12 +16,13 @@ module.exports = {
             .setDescription('The new name of the category')
             .setRequired(true)
         ),
-	execute(interaction) {
+	async execute(interaction) {
+	        await interaction.deferReply({ flags: 64 });
         const category = interaction.options.getString('category');
         const newCategory = interaction.options.getString('newcategory');
 		(async () => {
 			reply = await shop.renameCategory(category, newCategory);
-            await interaction.reply(reply);
+            await interaction.editReply(reply);
 		})()
 	},
 };

--- a/commands/shopCommands/shop.js
+++ b/commands/shopCommands/shop.js
@@ -6,9 +6,9 @@ module.exports = {
 		.setName('shop')
 		.setDescription('List shop items'),
 	async execute(interaction) {
+	        await interaction.deferReply({ flags: 64 });
                 // const itemListString = await shop.shop();
-                // await interaction.reply(itemListString);
-               await interaction.deferReply({ ephemeral: true });
+                // await interaction.editReply(itemListString);
                let [embed, rows] = await shop.createShopEmbed(1, interaction);
                await interaction.editReply({ embeds: [embed], components: rows });
 	},

--- a/commands/shopCommands/updateAllItemVersions.js
+++ b/commands/shopCommands/updateAllItemVersions.js
@@ -6,16 +6,16 @@ module.exports = {
 		.setName('updateallitemversions')
 		.setDescription('Update the version of all items')
 		.setDefaultMemberPermissions(0),
-	execute(interaction) {
+	async execute(interaction) {
+	        await interaction.deferReply({ flags: 64 });
 		(async () => {
 			try {
-				await interaction.deferReply();
 				let response = await shop.updateAllItemVersions();
                                 if (process.env.DEBUG) console.log(response);  // Log the response for debugging
 				await interaction.editReply({ content: response });
 			} catch (error) {
 				console.error('Failed to update item versions:', error);
-				await interaction.reply({ content: 'Error updating item versions.', ephemeral: true });
+				await interaction.editReply({ content: 'Error updating item versions.' });
 			}
 		})();
 	},

--- a/commands/shopCommands/updateItemVersion.js
+++ b/commands/shopCommands/updateItemVersion.js
@@ -11,13 +11,14 @@ module.exports = {
 			.setDescription('The item name')
 			.setRequired(true)
 		),
-	execute(interaction) {
+	async execute(interaction) {
+	        await interaction.deferReply({ flags: 64 });
 		const itemName = interaction.options.getString('itemname');
 
 		(async () => {
 			//shop.editItemMenu returns an array with the first element being the replyEmbed and the second element being the rows
 			let reply = await shop.updateItemVersion(itemName);
-            interaction.reply(reply);
+            interaction.editReply(reply);
 		})()
 	},
 };


### PR DESCRIPTION
## Summary
- Defer all slash command responses with `interaction.deferReply({ flags: 64 })`
- Replace `interaction.reply` with `interaction.editReply` or `interaction.followUp`
- Drop `ephemeral` and `fetchReply` options and fetch replies explicitly when needed

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b84c604284832ebfb0e2ccd4143be8