### PR TITLE
feat: reuse shop data in getItemCategory

### DIFF
--- a/shop.js
+++ b/shop.js
@@ -729,8 +729,8 @@ class shop {
     return price;
   }
 
-  static async getItemCategory(itemName) {
-    let data = await dbm.loadCollection('shop');
+  static async getItemCategory(itemName, shopData = null) {
+    const data = shopData ?? await dbm.loadCollection('shop');
     var category;
     if (data[itemName]) {
       category = data[itemName].infoOptions.Category;


### PR DESCRIPTION
## Summary
- allow getItemCategory to accept optional shop data
- lazily load shop collection when needed

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b85c3601b4832eab783cf7e647c3e4