### PR TITLE
Preload shop and marketplace caches on client ready

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -7,6 +7,8 @@ const { Client, GatewayIntentBits, Collection, Events } = require('discord.js');
 const char = require('./char');
 const dbm = require('./database-manager');
 const admin = require('./admin');
+const shop = require('./shop');
+const marketplace = require('./marketplace');
 const client = new Client({ 
     intents: [
         GatewayIntentBits.Guilds,
@@ -47,7 +49,21 @@ for (const entry of entries) {
 
 client.on('ready', () => {
     if (process.env.DEBUG) console.log(`Logged in as ${client.user.tag}!`);
-	//client.user.setAvatar('https://cdn.discordapp.com/attachments/890351376004157440/1332678517888126986/NEW_LOGO_CLEAN_smallish.png?ex=6798c416&is=67977296&hm=ada5afdd0bcb677d3a0a1ca6aabe55f554810e3044048ac4e5cd85d0d73e7f0d&');
+        //client.user.setAvatar('https://cdn.discordapp.com/attachments/890351376004157440/1332678517888126986/NEW_LOGO_CLEAN_smallish.png?ex=6798c416&is=67977296&hm=ada5afdd0bcb677d3a0a1ca6aabe55f554810e3044048ac4e5cd85d0d73e7f0d&');
+    client.emit('clientReady');
+});
+
+client.on('clientReady', async () => {
+    [shop.shopCache, marketplace.marketplaceCache] = await Promise.all([
+        dbm.loadCollection('shop'),
+        dbm.loadCollection('marketplace')
+    ]);
+
+    // Preload additional frequently accessed collections
+    await Promise.all([
+        dbm.loadCollection('keys'),
+        dbm.loadCollection('recipes'),
+    ]);
 });
 
 // //message handler


### PR DESCRIPTION
## Summary
- import shop and marketplace modules in `bot.js`
- preload shop, marketplace, keys and recipes collections when the clientReady event fires

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b868ccc528832e8ef4041638084353