### PR TITLE
Preload shop and marketplace caches on ready

### DIFF
--- a/marketplace.js
+++ b/marketplace.js
@@ -6,6 +6,7 @@ const { EmbedBuilder, ButtonBuilder, ButtonStyle, ActionRowBuilder } = require('
 class marketplace {
   static shopDataCache = null;
   static marketplaceCache = null;
+  static saleIndex = {};
   /**Function for a player to post a sale.
    * Will take the number of items, the item name, and the price they want to sell it for.
    * Will also be passed their user ID


### PR DESCRIPTION
## Summary
- Load shop and marketplace data on client ready and share cache between modules
- Build sale index for fast lookup of sale category and item
- Add sale index property to marketplace module

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b887dfcd78832eb8b56e7c9c9d7eaa