### PR TITLE
feat: cache character data

### DIFF
--- a/admin.js
+++ b/admin.js
@@ -1,4 +1,5 @@
 const dbm = require('./database-manager'); // Importing the database manager
+const char = require('./char');
 const axios = require('axios');
 const { ActionRowBuilder, ButtonBuilder, ButtonStyle, EmbedBuilder, createWebhook, StringSelectMenuBuilder, StringSelectMenuOptionBuilder } = require('discord.js');
 const shop = require('./shop');
@@ -345,13 +346,13 @@ When selected grants the:
   
     mapData = mapData[mapName];
   
-    let userData = await dbm.loadFile('characters', String(numericID));
+    let [player, userData] = await char.findPlayerData(numericID);
     if (!userData.editingFields) {
       userData.editingFields = {};
     }
     userData.editingFields["Map Edited"] = mapName;
     userData.editingFields["Map Type Edited"] = mapType;
-    await dbm.saveFile('characters', String(numericID), userData);
+    await char.updatePlayer(player, userData);
   
     // Construct the edit menu embed
     const embed = new EmbedBuilder()
@@ -416,7 +417,7 @@ When selected grants the:
   
   static async editMapField(numericID, field, value) {
     // Load the maps collection
-    let charData = await dbm.loadFile('characters', String(numericID));
+    let [player, charData] = await char.findPlayerData(numericID);
     if (!charData.editingFields || !charData.editingFields["Map Edited"] || !charData.editingFields["Map Type Edited"]) {
       return "You must use /editmapmenu first to select a map to edit";
     }

--- a/commands/adminCommands/editembedaboutmodal.js
+++ b/commands/adminCommands/editembedaboutmodal.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder, ActionRowBuilder, ModalBuilder, TextInputBuilder, TextInputStyle } = require('discord.js');
 const admin = require('../../admin'); // Importing the database manager
+const char = require('../../char');
 const dbm = require ('../../database-manager');
 
 ///editfield <field number> <new value>
@@ -11,7 +12,7 @@ module.exports = {
     async execute(interaction) {
         try {
             const numericID = interaction.user.id;
-            let userData = await dbm.loadFile('characters', String(numericID));
+            let [player, userData] = await char.findPlayerData(numericID);
 
             let mapName = userData.editingFields["Map Edited"];
             let mapTypeEdited = userData.editingFields["Map Type Edited"];

--- a/commands/raid.js
+++ b/commands/raid.js
@@ -2,6 +2,7 @@ const { SlashCommandBuilder, StringSelectMenuBuilder, ActionRowBuilder, Componen
 const path = require('path');
 const raidUtils = require('../raidUtils');
 const dbm = require('../database-manager');
+const char = require('../char');
 const clientManager = require('../clientManager');
 
 // Custom display names for each difficulty
@@ -29,7 +30,7 @@ module.exports = {
     const numericID = interaction.user.id;
     const charId = String(numericID);
 
-    const charData = await dbm.loadFile('characters', charId);
+    const [player, charData] = await char.findPlayerData(charId);
     if (!charData) {
       await interaction.editReply({ content: 'Create a character first with /newchar.' });
       return;
@@ -197,7 +198,7 @@ module.exports = {
     }
 
     charData.lastRaidAt = now;
-    await dbm.saveFile('characters', charId, charData);
+    await char.updatePlayer(player, charData);
 
     await dbm.saveFile('raidLog', `${numericID}-${now}`, {
       user: charId,

--- a/dataGetters.js
+++ b/dataGetters.js
@@ -1,9 +1,9 @@
-const dbm = require('./database-manager');
+const char = require('./char');
 
 class dataGetters {
     static async getCharFromNumericID(numericID) {
-        const charData = await dbm.loadFile('characters', String(numericID));
-        return charData ? String(numericID) : 'ERROR';
+        const [idStr, charData] = await char.findPlayerData(numericID);
+        return charData ? idStr : 'ERROR';
     }
 }
 module.exports = dataGetters;

--- a/marketplace.js
+++ b/marketplace.js
@@ -18,7 +18,7 @@ class marketplace {
     const shopData = marketplace.shopDataCache;
 
     // Load the character file
-    const charData = await dbm.loadFile('characters', String(sellerID));
+    const [sellerIDStr, charData] = await char.findPlayerData(sellerID);
     const mktData = marketplace.marketplaceCache || { idfile: { lastID: 1000 }, marketplace: {} };
     marketplace.marketplaceCache = mktData;
     // Find the item name using shop.findItemName
@@ -55,7 +55,7 @@ class marketplace {
     }
     // Save the character.json file and update marketplace data in parallel
     await Promise.all([
-      dbm.saveFile('characters', String(sellerID), charData),
+      char.updatePlayer(sellerIDStr, charData),
       dbm.saveCollection('marketplace', mktData)
     ]);
     marketplace.marketplaceCache = mktData;
@@ -262,9 +262,9 @@ class marketplace {
     }
 
     // Load buyer and seller characters in parallel
-    const [buyerChar, sellerChar] = await Promise.all([
-      dbm.loadFile('characters', String(buyerID)),
-      dbm.loadFile('characters', String(sale.sellerID))
+    const [[buyerIDStr, buyerChar], [sellerIDStr, sellerChar]] = await Promise.all([
+      char.findPlayerData(buyerID),
+      char.findPlayerData(sale.sellerID)
     ]);
 
     // If the buyer is the seller, give them back the items
@@ -274,7 +274,7 @@ class marketplace {
       delete marketData.marketplace[foundCategory][foundItemName][saleID];
       delete marketplace.saleIndex[saleID];
       await Promise.all([
-        dbm.saveFile('characters', String(buyerID), buyerChar),
+        char.updatePlayer(buyerIDStr, buyerChar),
         dbm.saveCollection('marketplace', marketData)
       ]);
       marketplace.marketplaceCache = marketData;
@@ -302,8 +302,8 @@ class marketplace {
 
     // Save updated character files and marketplace
     await Promise.all([
-      dbm.saveFile('characters', String(buyerID), buyerChar),
-      dbm.saveFile('characters', String(sale.sellerID), sellerChar),
+      char.updatePlayer(buyerIDStr, buyerChar),
+      char.updatePlayer(sellerIDStr, sellerChar),
       dbm.saveCollection('marketplace', marketData)
     ]);
     marketplace.marketplaceCache = marketData;


### PR DESCRIPTION
## Summary
- cache character files in `char` to reduce repeated database reads
- expose `updatePlayer` helper to persist and refresh cache entries
- use cached helpers across marketplace, shop, admin and raid flows

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b8b25b66c0832eb943aa8acfd4ede5