### PR TITLE
Warm marketplace cache at startup

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -50,20 +50,17 @@ for (const entry of entries) {
         }
 }
 
-client.on('ready', () => {
+client.once(Events.ClientReady, async () => {
     if (process.env.DEBUG) console.log(`Logged in as ${client.user.tag}!`);
-        //client.user.setAvatar('https://cdn.discordapp.com/attachments/890351376004157440/1332678517888126986/NEW_LOGO_CLEAN_smallish.png?ex=6798c416&is=67977296&hm=ada5afdd0bcb677d3a0a1ca6aabe55f554810e3044048ac4e5cd85d0d73e7f0d&');
-    client.emit('clientReady');
-});
+    console.log('Bot ready, loading marketplace cache…');
+    await marketplace.loadMarketplace();
+    console.log('Marketplace cache loaded');
 
-client.on('clientReady', async () => {
     const preloadChars = (process.env.PRELOAD_CHAR_IDS || '').split(',').filter(Boolean);
 
-    // Load all required collections in parallel
+    // Load remaining collections in parallel
     const [shopData] = await Promise.all([
         shop.getShopData(),
-        // Pre-warm marketplace cache and sale index at startup
-        marketplace.loadMarketplace(),
         dbm.loadCollection('keys'),
         dbm.loadCollection('recipes'),
         ...preloadChars.map(id => char.findPlayerData(id.trim()))

--- a/marketplace.js
+++ b/marketplace.js
@@ -17,11 +17,12 @@ class marketplace {
    * to their locations. Subsequent calls will return the cached data unless a refresh is requested.
    * @param {boolean} refresh - force reload even if cache exists
    * @returns {Promise<{idfile: object, marketplace: object}>}
-   */
+  */
   static async loadMarketplace(refresh = false) {
     if (marketplace.marketplaceCache && !refresh) {
       return marketplace.marketplaceCache;
     }
+    console.log('Loading marketplace data from DB…');
     const rows = await dbm.loadCollection('marketplace');
     const { idfile = {}, ...salesRows } = rows;
     const mktData = { idfile, marketplace: {} };
@@ -42,6 +43,7 @@ class marketplace {
     }
     marketplace.marketplaceCache = mktData;
     marketplace.saleIndex = index;
+    console.log('Marketplace data loaded and cached');
     return mktData;
   }
 


### PR DESCRIPTION
## Summary
- Warm marketplace cache during client startup to avoid first-command delay
- Add debug logging around marketplace DB load

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9e7de72bc832eb4cae790c78ce4b4