### PR TITLE
feat: add mining ships to catalog

### DIFF
--- a/jsonStorage/shipCatalog.json
+++ b/jsonStorage/shipCatalog.json
@@ -3,5 +3,7 @@
   "Destroyer": { "tier": 2, "attack": 70, "defense": 55, "speed": 65, "hp": 550 },
   "Heavy Frigate": { "tier": 3, "attack": 90, "defense": 75, "speed": 45, "hp": 800 },
   "Cruiser": { "tier": 4, "attack": 130, "defense": 90, "speed": 35, "hp": 1200 },
-  "Battleship": { "tier": 5, "attack": 170, "defense": 110, "speed": 25, "hp": 1800 }
+  "Battleship": { "tier": 5, "attack": 170, "defense": 110, "speed": 25, "hp": 1800 },
+  "Miner": { "tier": 1, "attack": 20, "defense": 15, "speed": 80, "hp": 250 },
+  "Atlas": { "tier": 2, "attack": 60, "defense": 40, "speed": 55, "hp": 700 }
 }

--- a/shop.js
+++ b/shop.js
@@ -13,6 +13,7 @@ const {
   updatePlayer,
 } = require('./shared/shop-char-utils');
 const { clearShopCache } = require('./cache-utils');
+const { loadShipCatalog } = require('./shipUtils');
 
 class shop {
   //Declare constants for class
@@ -521,6 +522,7 @@ class shop {
     // load data for this character and shop.json
     const [player, charData] = await findPlayerData(charID);
     const shopData = await getShopData();
+    const shipCatalog = await loadShipCatalog();
 
     // If character doesn't exist, instruct user to create one
     if (!charData) {
@@ -540,9 +542,18 @@ class shop {
         continue;
       }
       if (!shopData[item]) {
-        deleted = true;
-        delete charData.inventory[item];
-        continue;
+        if (shipCatalog[item]) {
+          const category = 'Ships';
+          if (!inventory[category]) {
+            inventory[category] = [];
+          }
+          inventory[category].push(item);
+          continue;
+        } else {
+          deleted = true;
+          delete charData.inventory[item];
+          continue;
+        }
       }
       const category = shopData[item].infoOptions.Category;
       if (!inventory[category]) {
@@ -572,7 +583,7 @@ class shop {
       descriptionText += `**\`--${category}${endSpaces}\`**\n`;
       descriptionText += inventory[category]
         .map((item) => {
-          const icon = shopData[item].infoOptions.Icon;
+          const icon = shopData[item]?.infoOptions.Icon || clientManager.getEmoji(item) || '🚀';
           const quantity = charData.inventory[item];
 
           let alignSpaces = ' ' 


### PR DESCRIPTION
## Summary
- expand ship catalog with Miner and Atlas entries
- allow inventory UI to surface ships not defined in shop data

## Testing
- `npm test`
- `npm run seed:once` *(fails: Missing required configuration: token, clientId, guildId, databaseUrl)*

------
https://chatgpt.com/codex/tasks/task_e_68c1ec547ad4832e8a2005fffaa4a264