### PR TITLE
feat: extend raid and mine cooldowns

### DIFF
--- a/commands/mine.js
+++ b/commands/mine.js
@@ -26,10 +26,12 @@ module.exports = {
     }
 
     const now = Date.now();
-    const COOLDOWN = 3 * 60 * 1000; // 3 minutes
+    const COOLDOWN = 24 * 60 * 60 * 1000; // 1 day
     if (charData.lastMineAt && now - charData.lastMineAt < COOLDOWN) {
-      const mins = Math.ceil((COOLDOWN - (now - charData.lastMineAt)) / 60000);
-      await interaction.editReply({ content: `You must wait ${mins} more minutes before mining again.` });
+      const remaining = COOLDOWN - (now - charData.lastMineAt);
+      const hours = Math.floor(remaining / (60 * 60 * 1000));
+      const minutes = Math.ceil((remaining % (60 * 60 * 1000)) / 60000);
+      await interaction.editReply({ content: `You must wait ${hours} hours and ${minutes} minutes before mining again.` });
       return;
     }
 

--- a/commands/raid.js
+++ b/commands/raid.js
@@ -43,10 +43,13 @@ module.exports = {
     }
 
     const now = Date.now();
-    const COOLDOWN = 3 * 60 * 1000; // 1 hour
+    const COOLDOWN = 3 * 24 * 60 * 60 * 1000; // 3 days
     if (charData.lastRaidAt && now - charData.lastRaidAt < COOLDOWN) {
-      const mins = Math.ceil((COOLDOWN - (now - charData.lastRaidAt)) / 60000);
-      await interaction.editReply({ content: `You must wait ${mins} more minutes before raiding again.` });
+      const remaining = COOLDOWN - (now - charData.lastRaidAt);
+      const hoursRemaining = Math.ceil(remaining / (60 * 60 * 1000));
+      const days = Math.floor(hoursRemaining / 24);
+      const hours = hoursRemaining % 24;
+      await interaction.editReply({ content: `You must wait ${days} days and ${hours} hours before raiding again.` });
       return;
     }
 


### PR DESCRIPTION
## Summary
- extend raid command cooldown to 3 days
- display remaining raid cooldown in days and hours
- extend mine command cooldown to 1 day
- display remaining mine cooldown in hours and minutes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c53d59be14832eab661c8d940dcb91