### PR TITLE
feat: enforce daily harvest cooldown

### DIFF
--- a/commands/harvest.js
+++ b/commands/harvest.js
@@ -78,10 +78,12 @@ module.exports = {
     }
 
     const now = Date.now();
-    const COOLDOWN = 3 * 60 * 1000; // 3 minutes
+    const COOLDOWN = 24 * 60 * 60 * 1000; // 1 day
     if (charData.lastHarvestAt && now - charData.lastHarvestAt < COOLDOWN) {
-      const mins = Math.ceil((COOLDOWN - (now - charData.lastHarvestAt)) / 60000);
-      await interaction.editReply({ content: `You must wait ${mins} more minutes before harvesting again.` });
+      const remaining = COOLDOWN - (now - charData.lastHarvestAt);
+      const hours = Math.floor(remaining / (60 * 60 * 1000));
+      const minutes = Math.floor((remaining % (60 * 60 * 1000)) / (60 * 1000));
+      await interaction.editReply({ content: `You must wait ${hours} hours and ${minutes} minutes before harvesting again.` });
       return;
     }
 

--- a/tests/harvest.test.js
+++ b/tests/harvest.test.js
@@ -62,7 +62,7 @@ test('harvest command cooldown enforcement', async (t) => {
   };
 
   await harvestCmd.execute(interaction);
-  assert.equal(reply.content, 'You must wait 3 more minutes before harvesting again.');
+  assert.equal(reply.content, 'You must wait 23 hours and 59 minutes before harvesting again.');
 });
 
 test('harvest command normal flow', async (t) => {
@@ -70,7 +70,7 @@ test('harvest command normal flow', async (t) => {
   const now = Date.now();
   t.mock.method(Date, 'now', () => now);
 
-  const charData = { fleet: { Harvester: 1, Aether: 1 }, inventory: {}, lastHarvestAt: now - 4 * 60 * 1000 };
+  const charData = { fleet: { Harvester: 1, Aether: 1 }, inventory: {}, lastHarvestAt: now - 25 * 60 * 60 * 1000 };
   t.mock.method(clientManager, 'getHarvestSession', () => null);
   t.mock.method(clientManager, 'setHarvestSession', () => {});
   t.mock.method(clientManager, 'clearHarvestSession', () => {});


### PR DESCRIPTION
## Summary
- extend harvest cooldown to 24 hours and show remaining hours/minutes
- adjust harvest tests for new cooldown

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c69c985b20832e88364491d8399218