### PR TITLE
Show character commands by default

### DIFF
--- a/commands/helpCommands/help.js
+++ b/commands/helpCommands/help.js
@@ -15,7 +15,7 @@ module.exports = {
             let command = interaction.options.getString('command');
 
             if (command == null) {
-                let [embed, rows] = await admin.generalHelpMenu(1, false);
+                let [embed, rows] = await admin.generalHelpMenu(2, false);
                 await interaction.editReply({ embeds: [embed], components: rows});
                 return;
             } else {

--- a/commands/helpCommands/helpadmin.js
+++ b/commands/helpCommands/helpadmin.js
@@ -15,7 +15,7 @@ module.exports = {
             let command = interaction.options.getString('command');
 
             if (command == null) {
-                let [embed, rows] = await admin.generalHelpMenu(1, true);
+                let [embed, rows] = await admin.generalHelpMenu(2, true);
                 await interaction.editReply({ embeds: [embed], components: rows});
                 return;
             } else {


### PR DESCRIPTION
## Summary
- default `/help` and `/helpadmin` pages now show Character Commands after Getting Started moved to page 1

## Testing
- `TOKEN=1 CLIENT_ID=1 GUILD_ID=1 DATABASE_URL=1 node -e "const admin=require('./admin');admin.generalHelpMenu(1,false).then(([embed,rows])=>{console.log('title',embed.data.title);console.log('buttons',rows[0].components.map(b=>b.data.custom_id));});"`
- `TOKEN=1 CLIENT_ID=1 GUILD_ID=1 DATABASE_URL=1 node -e "const admin=require('./admin');admin.generalHelpMenu(2,false).then(([embed,rows])=>{console.log('title',embed.data.title);console.log('buttons',rows[0].components.map(b=>b.data.custom_id));});"`
- `TOKEN=1 CLIENT_ID=1 GUILD_ID=1 DATABASE_URL=1 node -e "const admin=require('./admin');admin.generalHelpMenu(2,true).then(([embed,rows])=>{console.log('title',embed.data.title);console.log('buttons',rows[0].components.map(b=>b.data.custom_id));});"`
- `npm test` *(fails: trade command cooldown enforcement, trade command normal flow)*

------
https://chatgpt.com/codex/tasks/task_e_68c6d2b485d0832e9acc657442ceca51