### PR TITLE
Open general help to first page

### DIFF
--- a/commands/helpCommands/help.js
+++ b/commands/helpCommands/help.js
@@ -15,7 +15,7 @@ module.exports = {
             let command = interaction.options.getString('command');
 
             if (command == null) {
-                let [embed, rows] = await admin.generalHelpMenu(2, false);
+                let [embed, rows] = await admin.generalHelpMenu(1, false);
                 await interaction.editReply({ embeds: [embed], components: rows});
                 return;
             } else {
@@ -31,5 +31,5 @@ module.exports = {
             console.error("Failed to help:", error);
             await interaction.editReply({ content: "Failed to help. Please try again." });
         }
-	},
+        },
 };

--- a/commands/helpCommands/helpadmin.js
+++ b/commands/helpCommands/helpadmin.js
@@ -15,7 +15,7 @@ module.exports = {
             let command = interaction.options.getString('command');
 
             if (command == null) {
-                let [embed, rows] = await admin.generalHelpMenu(2, true);
+                let [embed, rows] = await admin.generalHelpMenu(1, true);
                 await interaction.editReply({ embeds: [embed], components: rows});
                 return;
             } else {
@@ -31,5 +31,5 @@ module.exports = {
             console.error("Failed to help:", error);
             await interaction.editReply({ content: "Failed to help. Please try again." });
         }
-	},
+        },
 };


### PR DESCRIPTION
## Summary
- Show user help menus starting on page 1 instead of page 2
- Apply the same first-page default to admin help command

## Testing
- `npm test` *(fails: trade command cooldown enforcement, trade command normal flow)*

------
https://chatgpt.com/codex/tasks/task_e_68c6d8d668c8832ea5d04a48d8d67e86