### PR TITLE
Validate purchase quantities

### DIFF
--- a/commands/shopCommands/buyitem.js
+++ b/commands/shopCommands/buyitem.js
@@ -5,11 +5,12 @@ module.exports = {
 	data: new SlashCommandBuilder()
 		.setName('buyitem')
 		.setDescription('Buy an item')
-        .addIntegerOption((option) => 
-        option.setName('numbertobuy')
-			.setDescription('How many do you want to buy')
-			.setRequired(true)
-		)
+.addIntegerOption((option) =>
+option.setName('numbertobuy')
+.setDescription('How many do you want to buy')
+.setMinValue(1)
+.setRequired(true)
+)
 		.addStringOption((option) =>
 		option.setName('itemname')
 			.setDescription('The item name')

--- a/shop.js
+++ b/shop.js
@@ -1504,6 +1504,9 @@ class shop {
   } 
 
   static async buyItem(itemName, charID, numToBuy, channelId) {
+    if (!Number.isInteger(numToBuy) || numToBuy <= 0) {
+      return "Invalid quantity to purchase!";
+    }
     let shopData = await getShopData();
     itemName = await findItemName(itemName, shopData);
     if (itemName == "ERROR") {


### PR DESCRIPTION
## Summary
- ensure the buyitem slash command enforces a minimum quantity of one client-side
- add a server-side guard in Shop.buyItem that rejects non-positive purchase counts early

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ca7ee6056c832eb66bf5e824e02d2d