### PR TITLE
Ensure boundShips defaults apply to legacy characters

### DIFF
--- a/char.js
+++ b/char.js
@@ -57,6 +57,7 @@ class char {
           "Corvette": 1
         },
         fleet: {},
+        boundShips: {},
         incomeList: {},
         incomeAvailable: true,
         stats: { HP: 100, STR: 0, DEX: 0, INT: 0, CHA: 0 },
@@ -67,6 +68,10 @@ class char {
         shireID: 0,
         numericID: numericID,
       };
+    }
+
+    if (!charData.boundShips || typeof charData.boundShips !== 'object') {
+      charData.boundShips = {};
     }
 
     // Save the character data

--- a/shared/bound-ships.js
+++ b/shared/bound-ships.js
@@ -1,0 +1,93 @@
+function ensureBoundShips(charData) {
+  if (!charData.boundShips || typeof charData.boundShips !== 'object') {
+    charData.boundShips = {};
+  }
+  return charData.boundShips;
+}
+
+function bindShipsForMission(charData, selection) {
+  ensureBoundShips(charData);
+  if (!charData.fleet) charData.fleet = {};
+  if (!charData.inventory) charData.inventory = {};
+
+  for (const [ship, qty] of Object.entries(selection || {})) {
+    if (!qty || qty <= 0) continue;
+
+    const currentBound = charData.boundShips[ship] || 0;
+    const tradeableFleet = charData.fleet[ship] || 0;
+    const tradeableInventory = charData.inventory[ship] || 0;
+    const tradeableTotal = tradeableFleet + tradeableInventory;
+
+    const neededFromTradeable = Math.max(0, qty - Math.min(qty, currentBound));
+    if (neededFromTradeable <= 0 || tradeableTotal <= 0) {
+      continue;
+    }
+
+    const convertible = Math.min(neededFromTradeable, tradeableTotal);
+    let remainingToConvert = convertible;
+
+    if (tradeableFleet > 0) {
+      const fromFleet = Math.min(remainingToConvert, tradeableFleet);
+      charData.fleet[ship] = tradeableFleet - fromFleet;
+      if (charData.fleet[ship] <= 0) {
+        delete charData.fleet[ship];
+      }
+      remainingToConvert -= fromFleet;
+    }
+
+    if (remainingToConvert > 0 && tradeableInventory > 0) {
+      const fromInventory = Math.min(remainingToConvert, tradeableInventory);
+      charData.inventory[ship] = tradeableInventory - fromInventory;
+      if (charData.inventory[ship] <= 0) {
+        delete charData.inventory[ship];
+      }
+      remainingToConvert -= fromInventory;
+    }
+
+    const converted = convertible - remainingToConvert;
+    if (converted > 0) {
+      charData.boundShips[ship] = (charData.boundShips[ship] || 0) + converted;
+    }
+  }
+}
+
+function applyShipCasualties(charData, casualties) {
+  ensureBoundShips(charData);
+  for (const [ship, lost] of Object.entries(casualties || {})) {
+    let remaining = lost;
+    if (remaining <= 0) continue;
+
+    if (charData.boundShips && charData.boundShips[ship]) {
+      const fromBound = Math.min(remaining, charData.boundShips[ship]);
+      charData.boundShips[ship] -= fromBound;
+      if (charData.boundShips[ship] <= 0) {
+        delete charData.boundShips[ship];
+      }
+      remaining -= fromBound;
+    }
+
+    if (remaining > 0 && charData.fleet && charData.fleet[ship]) {
+      const fromFleet = Math.min(remaining, charData.fleet[ship]);
+      charData.fleet[ship] -= fromFleet;
+      if (charData.fleet[ship] <= 0) {
+        delete charData.fleet[ship];
+      }
+      remaining -= fromFleet;
+    }
+
+    if (remaining > 0 && charData.inventory && charData.inventory[ship]) {
+      const fromInventory = Math.min(remaining, charData.inventory[ship]);
+      charData.inventory[ship] -= fromInventory;
+      if (charData.inventory[ship] <= 0) {
+        delete charData.inventory[ship];
+      }
+      remaining -= fromInventory;
+    }
+  }
+}
+
+module.exports = {
+  ensureBoundShips,
+  bindShipsForMission,
+  applyShipCasualties
+};

--- a/shared/shop-char-utils.js
+++ b/shared/shop-char-utils.js
@@ -1,4 +1,5 @@
 const dbm = require('../database-manager');
+const { ensureBoundShips } = require('./bound-ships');
 
 // Utilities shared between char.js and shop.js
 // Avoid importing char.js or shop.js here to prevent circular dependencies.
@@ -45,12 +46,15 @@ const charCache = new Map();
 async function findPlayerData(id) {
   const player = String(id);
   if (charCache.has(player)) {
-    return [player, charCache.get(player)];
+    const cached = charCache.get(player);
+    ensureBoundShips(cached);
+    return [player, cached];
   }
   const charData = await dbm.loadFile('characters', player);
   if (!charData) {
     return [false, false];
   }
+  ensureBoundShips(charData);
   charCache.set(player, charData);
   return [player, charData];
 }

--- a/tests/bound-ships-compat.test.js
+++ b/tests/bound-ships-compat.test.js
@@ -1,0 +1,24 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+process.env.TOKEN = process.env.TOKEN || 'test';
+process.env.CLIENT_ID = process.env.CLIENT_ID || 'test';
+process.env.GUILD_ID = process.env.GUILD_ID || 'test';
+process.env.DATABASE_URL = process.env.DATABASE_URL || 'postgres://user:pass@localhost:5432/db';
+
+const shopCharUtils = require('../shared/shop-char-utils');
+const dbm = require('../database-manager');
+
+test('findPlayerData supplies default boundShips for existing characters', async (t) => {
+  shopCharUtils.charCache.clear();
+  t.mock.method(dbm, 'loadFile', async () => ({ name: 'Existing Player' }));
+
+  const [id, charData] = await shopCharUtils.findPlayerData('12345');
+  assert.equal(id, '12345');
+  assert.deepEqual(charData.boundShips, {});
+
+  // Cached call should retain the boundShips field
+  const [cachedId, cachedData] = await shopCharUtils.findPlayerData('12345');
+  assert.equal(cachedId, '12345');
+  assert.deepEqual(cachedData.boundShips, {});
+});


### PR DESCRIPTION
## Summary
- default boundShips when loading character data through the shared cache utility so legacy profiles stay tradeable until used
- add a regression test covering the cached and uncached pathways for findPlayerData

## Testing
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_e_68d67090ecf8832e916840800bdda651