### PR TITLE
Style ship inventory lines

### DIFF
--- a/shop.js
+++ b/shop.js
@@ -632,8 +632,21 @@ class shop {
           }
 
           if (boundCount > 0) {
-            categoryLines.push(`${item} – tradeable × ${tradeableCount}`);
-            categoryLines.push(`${item} – bound × ${boundCount}`);
+            const icon = shopData[item]?.infoOptions?.Icon || clientManager.getEmoji(item) || '';
+
+            const tradeableLabel = `${item} – tradeable × ${tradeableCount}`;
+            let tradeableAlignSpaces = ' ';
+            if ((30 - tradeableLabel.length) > 0) {
+              tradeableAlignSpaces = ' '.repeat(30 - tradeableLabel.length);
+            }
+            categoryLines.push(`${icon} \`${tradeableLabel}${tradeableAlignSpaces}\``);
+
+            const boundLabel = `${item} – bound × ${boundCount}`;
+            let boundAlignSpaces = ' ';
+            if ((30 - boundLabel.length) > 0) {
+              boundAlignSpaces = ' '.repeat(30 - boundLabel.length);
+            }
+            categoryLines.push(`${icon} \`${boundLabel}${boundAlignSpaces}\``);
           } else {
             const icon = shopData[item]?.infoOptions?.Icon || clientManager.getEmoji(item) || '🚀';
             const quantity = tradeableCount;


### PR DESCRIPTION
## Summary
- wrap bound and tradeable ship inventory rows with icons and inline code styling for consistency
- align ship labels to the existing width while keeping the existing logic for when bound ships display

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6ad2977fc832ea5927c7c923f484a