### PR TITLE
Add KZ90 research ship to catalog and trade rewards

### DIFF
--- a/commands/trade.js
+++ b/commands/trade.js
@@ -22,7 +22,7 @@ const TRADE_RULES = {
         'A corrupt dockmaster seized part of the cargo.',
         'An unexpected tariff cut into your earnings.'
       ],
-      compensation: ['Bridger', 'Miner', 'Harvester']
+      compensation: ['KZ90', 'Bridger', 'Miner', 'Harvester']
     }
   },
   FEDERATION: {
@@ -36,7 +36,7 @@ const TRADE_RULES = {
         'A rival trader undercut your deal.',
         'Storms damaged part of your cargo.'
       ],
-      compensation: ['Bridger', 'Miner', 'Harvester']
+      compensation: ['KZ90', 'Bridger', 'Miner', 'Harvester']
     }
   },
   DOMINION: {
@@ -50,7 +50,7 @@ const TRADE_RULES = {
         'Bandits made off with part of the haul.',
         'Local warlords extorted your caravans.'
       ],
-      compensation: ['Bridger', 'Miner', 'Harvester']
+      compensation: ['KZ90', 'Bridger', 'Miner', 'Harvester']
     },
     shipLoss: {
       chanceRange: [5, 10],

--- a/jsonStorage/shipCatalog.json
+++ b/jsonStorage/shipCatalog.json
@@ -9,5 +9,6 @@
   "Aether": { "tier": 1, "attack": 0, "defense": 10, "speed": 70, "hp": 300 },
   "Harvester": { "tier": 1, "attack": 0, "defense": 8, "speed": 60, "hp": 250 },
   "Freighter": { "tier": 1, "attack": 0, "defense": 5, "speed": 50, "hp": 500 },
-  "Bridger": { "tier": 1, "attack": 0, "defense": 6, "speed": 55, "hp": 550 }
+  "Bridger": { "tier": 1, "attack": 0, "defense": 6, "speed": 55, "hp": 550 },
+  "KZ90": { "tier": 3, "attack": 35, "defense": 60, "speed": 80, "hp": 750 }
 }

--- a/seeds/seedOnBoot.js
+++ b/seeds/seedOnBoot.js
@@ -5,15 +5,32 @@ const path = require('path');
 async function run() {
   async function seedCollectionIfEmpty(collectionName, jsonRelPath) {
     const existing = await dbm.loadCollection(collectionName);
+    const filePath = path.join(__dirname, '..', 'jsonStorage', jsonRelPath);
+    const raw = await fs.promises.readFile(filePath, 'utf8');
+    const data = JSON.parse(raw);
+
     if (Object.keys(existing).length === 0) {
-      const filePath = path.join(__dirname, '..', 'jsonStorage', jsonRelPath);
-      const raw = await fs.promises.readFile(filePath, 'utf8');
-      const data = JSON.parse(raw);
       await dbm.saveCollection(collectionName, data);
       if (process.env.DEBUG) console.log(`[seed] ${collectionName}: seeded.`);
-    } else {
-      if (process.env.DEBUG) console.log(`[seed] ${collectionName}: skipped, already has data.`);
+      return;
     }
+
+    let needsUpdate = false;
+    for (const [key, value] of Object.entries(data)) {
+      if (!existing.hasOwnProperty(key) || JSON.stringify(existing[key]) !== JSON.stringify(value)) {
+        needsUpdate = true;
+        break;
+      }
+    }
+
+    if (!needsUpdate) {
+      if (process.env.DEBUG) console.log(`[seed] ${collectionName}: up to date, skipped.`);
+      return;
+    }
+
+    const merged = { ...existing, ...data };
+    await dbm.saveCollection(collectionName, merged);
+    if (process.env.DEBUG) console.log(`[seed] ${collectionName}: updated with new entries.`);
   }
 
   const ENABLED = process.env.SEED_ON_BOOT !== 'false';

--- a/tests/shipCatalog.test.js
+++ b/tests/shipCatalog.test.js
@@ -1,0 +1,23 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+process.env.TOKEN = process.env.TOKEN || 'test';
+process.env.CLIENT_ID = process.env.CLIENT_ID || 'test';
+process.env.GUILD_ID = process.env.GUILD_ID || 'test';
+process.env.DATABASE_URL = process.env.DATABASE_URL || 'postgres://user:pass@localhost:5432/db';
+
+const dbm = require('../database-manager');
+const shipUtils = require('../shipUtils');
+const shipCatalog = require('../jsonStorage/shipCatalog.json');
+
+test('shipUtils exposes catalog stats for KZ90', async (t) => {
+  t.mock.method(dbm, 'loadCollection', async (collectionName) => {
+    if (collectionName === 'shipCatalog') {
+      return shipCatalog;
+    }
+    return {};
+  });
+
+  const stats = await shipUtils.getShipStats('KZ90');
+  assert.deepStrictEqual(stats, shipCatalog['KZ90']);
+});

--- a/tests/trade.test.js
+++ b/tests/trade.test.js
@@ -37,7 +37,7 @@ test('performTrade earnings and loss logic', async (t) => {
     const now = Date.now();
     const charData = { fleet: { Bridger: 1, Freighter: 1 }, inventory: {}, balance: 0, boundShips: {} };
     const submitted = { Bridger: 1, Freighter: 1 };
-    // earnings 150 + floor(150*1.5) = 375, money loss 75, ship loss 1 Bridger, compensation Horse
+    // earnings 150 + floor(150*1.5) = 375, money loss 75, ship loss 1 Bridger, compensation KZ90 research hull
     const rand = makeRand([0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
     const res = tradeCmd._performTrade(charData, 'DOMINION', submitted, now, rand);
     assert.equal(res.earnings, 375);
@@ -47,9 +47,9 @@ test('performTrade earnings and loss logic', async (t) => {
     assert.equal(charData.fleet.Freighter, undefined);
     assert.equal(charData.boundShips.Bridger, undefined);
     assert.equal(charData.boundShips.Freighter, 1);
-    assert.equal(charData.inventory.Horse, 1);
+    assert.equal(charData.inventory.KZ90, 1);
     assert.equal(charData.balance, 300);
-    assert.equal(res.compensationItem, 'Horse');
+    assert.equal(res.compensationItem, 'KZ90');
   });
 });
 


### PR DESCRIPTION
## Summary
- add the KZ90 research hull to the shared ship catalog and merge it into persisted data when seeding
- allow trade compensation pools to award the new ship and adjust expectations to match
- add a focused unit test to ensure shipUtils exposes the catalog entry for KZ90

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd2f3803d0832e95cbd76becb7814b