### PR TITLE
Shorten exploration cooldown to two minutes

### DIFF
--- a/commands/explore.js
+++ b/commands/explore.js
@@ -190,10 +190,17 @@ module.exports = {
       const now = Date.now();
       if (charData.lastExploreAt && now - charData.lastExploreAt < COOLDOWN_MS) {
         const remaining = COOLDOWN_MS - (now - charData.lastExploreAt);
-        const mins = Math.ceil(remaining / 60000);
-        const hours = Math.floor(mins / 60);
-        const minutes = mins % 60;
-        await interaction.editReply({ content: `You must wait ${hours} hours and ${minutes} minutes before exploring again.` });
+        const totalSeconds = Math.ceil(remaining / 1000);
+        const minutes = Math.floor(totalSeconds / 60);
+        const seconds = totalSeconds % 60;
+        const parts = [];
+        if (minutes > 0) {
+          parts.push(`${minutes} minute${minutes === 1 ? '' : 's'}`);
+        }
+        if (seconds > 0 || parts.length === 0) {
+          parts.push(`${seconds} second${seconds === 1 ? '' : 's'}`);
+        }
+        await interaction.editReply({ content: `You must wait ${parts.join(' and ')} before exploring again.` });
         return;
       }
 

--- a/shared/explore-data.js
+++ b/shared/explore-data.js
@@ -1,5 +1,5 @@
 const EXPLORE_IMAGE = 'https://i.imgur.com/zCEGfel.jpeg';
-const COOLDOWN_MS = 3 * 24 * 60 * 60 * 1000; // 3 days
+const COOLDOWN_MS = 2 * 60 * 1000; // 2 minutes
 
 const CURIO_DEFINITIONS = {
   'Glass-Sand Urn': { gold: 1000 },

--- a/tests/exploreCommand.test.js
+++ b/tests/exploreCommand.test.js
@@ -119,12 +119,12 @@ test('explore command enforces cooldown window', { concurrency: false }, async (
   stubNow(t, now);
   stubRandomSequence(t, [0.1]);
 
-  const remainingMinutes = 90;
+  const remainingSeconds = 90;
   const charData = {
     boundShips: { KZ90: 1 },
     fleet: {},
     inventory: { KZ90: 1 },
-    lastExploreAt: now - (COOLDOWN_MS - remainingMinutes * 60_000)
+    lastExploreAt: now - (COOLDOWN_MS - remainingSeconds * 1000)
   };
 
   const updateMock = stubCharacterData(t, charData);
@@ -133,7 +133,7 @@ test('explore command enforces cooldown window', { concurrency: false }, async (
   await exploreCmd.execute(interaction);
 
   assert.equal(replies.edits.length, 1);
-  assert.match(replies.edits[0].content, /You must wait 1 hours and 30 minutes before exploring again\./);
+  assert.match(replies.edits[0].content, /You must wait 1 minute and 30 seconds before exploring again\./);
   assert.equal(replies.followUps.length, 0);
   assert.equal(updateMock.mock.calls.length, 0);
   assert.equal(sessionStore.size, 0);


### PR DESCRIPTION
## Summary
- reduce the shared exploration cooldown constant to two minutes
- adjust the user-facing cooldown warning to display minutes and seconds
- align the exploration command test expectations with the shorter cooldown

## Testing
- node --test tests/exploreCommand.test.js (manually interrupted after successful assertions due to long-running bot timers)


------
https://chatgpt.com/codex/tasks/task_e_68df824f9f08832e83ea5adb80e9943b