### PR TITLE
Restrict news dispatches to destroyed exploration outcomes

### DIFF
--- a/commands/explore.js
+++ b/commands/explore.js
@@ -87,6 +87,10 @@ function resolveReward(rewardConfig = {}) {
 }
 
 async function maybeSendNews(interaction, region, encounter, outcomeKey, rewardResult, rareShipAwarded) {
+  if (outcomeKey !== 'destroyed') {
+    return;
+  }
+
   const guild = interaction?.guild;
   if (!guild || !guild.channels?.cache) {
     return;
@@ -413,14 +417,16 @@ module.exports = {
           .setImage(EXPLORE_IMAGE);
 
         await interaction.followUp({ embeds: [reportEmbed], components: [], ephemeral: true });
-        await maybeSendNews(
-          interaction,
-          regionConfig,
-          encounter,
-          outcomeKey,
-          rewardResult,
-          rareShipAwarded
-        );
+        if (outcomeKey === 'destroyed') {
+          await maybeSendNews(
+            interaction,
+            regionConfig,
+            encounter,
+            outcomeKey,
+            rewardResult,
+            rareShipAwarded
+          );
+        }
 
         const resolvedSession = {
           ...clientManager.getExploreSession(numericID),


### PR DESCRIPTION
## Summary
- add an outcome guard to `maybeSendNews` so non-destroyed results are ignored
- only invoke the news dispatch helper when an exploration ends in ship loss

## Testing
- not run (Discord integration not available in test environment)


------
https://chatgpt.com/codex/tasks/task_e_68dfb6da9968832eb2747d1bb3bda291