### PR TITLE
Adjust explore curio reward odds

### DIFF
--- a/commands/explore.js
+++ b/commands/explore.js
@@ -61,7 +61,7 @@ function resolveReward(rewardConfig = {}) {
 
   let useCurioRewards = hasCurio;
   if (hasCurio && hasResourceRewards) {
-    useCurioRewards = Math.random() < 0.5;
+    useCurioRewards = Math.random() < 0.2;
   }
 
   if (useCurioRewards && curioId) {


### PR DESCRIPTION
## Summary
- update the explore reward resolver to only choose curios 20% of the time when salvage is also available
- ensure salvage remains the default reward path when curios are not selected

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dfc0e56a78832e845cca3057322402