### PR TITLE
Refine cooldown mission tracking display

### DIFF
--- a/commands/shared/explore-data.js
+++ b/commands/shared/explore-data.js
@@ -1,0 +1,1 @@
+module.exports = require('../../shared/explore-data');


### PR DESCRIPTION
## Summary
- import the explore cooldown constant for the character cooldown command and define mission cooldown durations
- remove crafting cooldown logic and show mission cooldowns in a consolidated field when active
- add a shared explore-data re-export so the new import path resolves for character commands

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2e1dd905c832e989c9e512f5478f7