### PR TITLE
Prevent privileged commands from running in DMs

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -102,20 +102,39 @@ client.once(Events.ClientReady, async () => {
 // });
 
 
+client.on(Events.MessageCreate, async message => {
+        // Ignore direct messages entirely to prevent bypassing permission checks
+        if (!message.guild) {
+                return;
+        }
+});
+
 //interaction handler
 client.on(Events.InteractionCreate, async interaction => {
-	//Ignore a specific user with id 614966892486197259
+        if (!interaction.inGuild()) {
+                if (interaction.isRepliable()) {
+                        const payload = { content: 'Commands can only be used within a server.', ephemeral: true };
+                        if (interaction.deferred || interaction.replied) {
+                                await interaction.followUp(payload);
+                        } else {
+                                await interaction.reply(payload);
+                        }
+                }
+                return;
+        }
 
-	if (interaction.isChatInputCommand()) {
-		const command = client.commands.get(interaction.commandName);
+        //Ignore a specific user with id 614966892486197259
 
-		try {
-			await command.execute(interaction);
-		} catch (error) {
-			console.error("THIS IS THE ERROR: " + error);
-			console.error(error);
-			console.error("BELOW IS THE REST OF THINGS");
-			if (interaction.replied || interaction.deferred) {
+        if (interaction.isChatInputCommand()) {
+                const command = client.commands.get(interaction.commandName);
+
+                try {
+                        await command.execute(interaction);
+                } catch (error) {
+                        console.error("THIS IS THE ERROR: " + error);
+                        console.error(error);
+                        console.error("BELOW IS THE REST OF THINGS");
+                        if (interaction.replied || interaction.deferred) {
                                 await interaction.followUp({ content: 'There was an error while executing this command!', flags: 64 });
                         } else {
                                 await interaction.reply({ content: 'There was an error while executing this command!', flags: 64 });

--- a/commands/adminCommands/addIncome.js
+++ b/commands/adminCommands/addIncome.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder } = require('discord.js');
 const admin = require('../../admin'); // Importing the database manager
+const { ensureAdminInteraction } = require('../../shared/interactionGuards');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -17,7 +18,10 @@ module.exports = {
                 .setRequired(true)
         ),
     async execute(interaction) {
-            await interaction.deferReply({ flags: 64 });
+        if (!(await ensureAdminInteraction(interaction))) {
+            return;
+        }
+        await interaction.deferReply({ flags: 64 });
         const role = interaction.options.getRole('role');
         const income = interaction.options.getString('income');
 

--- a/commands/adminCommands/addembed.js
+++ b/commands/adminCommands/addembed.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder } = require('discord.js');
 const admin = require('../../admin'); // Importing the database manager
+const { ensureAdminInteraction } = require('../../shared/interactionGuards');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -20,6 +21,9 @@ module.exports = {
                     {name: 'Rank', value: 'rank'},
                     {name: 'Guide', value: 'guide'})),
 	async execute(interaction) {
+	    if (!(await ensureAdminInteraction(interaction))) {
+	        return;
+	    }
 	        await interaction.deferReply({ flags: 64 });
 		try {
             let map = interaction.options.getString('embed');

--- a/commands/adminCommands/addplayerkingdoms.js
+++ b/commands/adminCommands/addplayerkingdoms.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder } = require('discord.js');
 const admin = require('../../admin'); // Importing the database manager
+const { ensureAdminInteraction } = require('../../shared/interactionGuards');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -11,6 +12,9 @@ module.exports = {
                 .setRequired(true))
         .setDefaultMemberPermissions(0),
 	async execute(interaction) {
+	    if (!(await ensureAdminInteraction(interaction))) {
+	        return;
+	    }
 	        await interaction.deferReply({ flags: 64 });
 		try {
             const kingdom = interaction.options.getRole('kingdom');

--- a/commands/adminCommands/allincomes.js
+++ b/commands/adminCommands/allincomes.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder } = require('discord.js');
 const admin = require('../../admin'); // Importing the database manager
+const { ensureAdminInteraction } = require('../../shared/interactionGuards');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -7,6 +8,9 @@ module.exports = {
 		.setDescription('List all incomes')
 		.setDefaultMemberPermissions(0),
 	async execute(interaction) {
+	    if (!(await ensureAdminInteraction(interaction))) {
+	        return;
+	    }
 	        await interaction.deferReply({ flags: 64 });
 		try {
             let reply = await admin.allIncomes(1);

--- a/commands/adminCommands/backupJson.js
+++ b/commands/adminCommands/backupJson.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder } = require('discord.js');
 const dbm = require('../../database-manager'); // Importing the database manager
+const { ensureAdminInteraction } = require('../../shared/interactionGuards');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -7,6 +8,9 @@ module.exports = {
 		.setDescription('Backup the JSON files')
 		.setDefaultMemberPermissions(0),
 	async execute(interaction) {
+	    if (!(await ensureAdminInteraction(interaction))) {
+	        return;
+	    }
 	        await interaction.deferReply({ flags: 64 });
         try {
             await dbm.logData();

--- a/commands/adminCommands/deploycommands.js
+++ b/commands/adminCommands/deploycommands.js
@@ -2,6 +2,7 @@ const { SlashCommandBuilder } = require('discord.js');
 const fs = require('fs');
 const path = require('path');
 const deploycommands = require('../../deploy-commands');
+const { ensureAdminInteraction } = require('../../shared/interactionGuards');
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -9,6 +10,9 @@ module.exports = {
     .setDefaultMemberPermissions(0)
     .setDescription('Deploy map commands'),
   async execute(interaction) {
+      if (!(await ensureAdminInteraction(interaction))) {
+          return;
+      }
           await interaction.deferReply({ flags: 64 });
     deploycommands.loadCommands();
     await interaction.editReply('Command files have been generated.');

--- a/commands/adminCommands/editembedaboutmodal.js
+++ b/commands/adminCommands/editembedaboutmodal.js
@@ -3,6 +3,7 @@ const admin = require('../../admin'); // Importing the database manager
 const char = require('../../char');
 const dbm = require ('../../database-manager');
 const keys = require('../../keys');
+const { ensureAdminInteraction } = require('../../shared/interactionGuards');
 
 ///editfield <field number> <new value>
 module.exports = {
@@ -11,6 +12,9 @@ module.exports = {
         .setDescription('Edit the about field of an embed. Use /editembedmenu first. Allows you to type paragraphs.')
         .setDefaultMemberPermissions(0),
     async execute(interaction) {
+        if (!(await ensureAdminInteraction(interaction))) {
+            return;
+        }
         try {
             const numericID = interaction.user.id;
             let [player, userData] = await char.findPlayerData(numericID);

--- a/commands/adminCommands/editembedfield.js
+++ b/commands/adminCommands/editembedfield.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder } = require('discord.js');
 const admin = require('../../admin'); // Importing the database manager
+const { ensureAdminInteraction } = require('../../shared/interactionGuards');
 
 ///editfield <field number> <new value>
 module.exports = {
@@ -18,7 +19,10 @@ module.exports = {
                 .setRequired(false)
         ),
     async execute(interaction) {
-            await interaction.deferReply({ flags: 64 });
+        if (!(await ensureAdminInteraction(interaction))) {
+            return;
+        }
+        await interaction.deferReply({ flags: 64 });
         const fieldNumber = interaction.options.getInteger('fieldnumber');
         let newValue;
         if (interaction.options.getString('newvalue') == null) {

--- a/commands/adminCommands/editembedmenu.js
+++ b/commands/adminCommands/editembedmenu.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder } = require('discord.js');
 const admin = require('../../admin'); // Importing the database manager
+const { ensureAdminInteraction } = require('../../shared/interactionGuards');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -21,7 +22,10 @@ module.exports = {
                     {name: 'Rank', value: 'rank'},
                     {name: 'Guide', value: 'guide'})),
     async execute(interaction) {
-            await interaction.deferReply({ flags: 64 });
+        if (!(await ensureAdminInteraction(interaction))) {
+            return;
+        }
+        await interaction.deferReply({ flags: 64 });
         const role = interaction.options.getString('embed');
         const type = interaction.options.getString('type');
         const numericID = interaction.user.id;

--- a/commands/adminCommands/editincomefield.js
+++ b/commands/adminCommands/editincomefield.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder } = require('discord.js');
 const admin = require('../../admin'); // Importing the database manager
+const { ensureAdminInteraction } = require('../../shared/interactionGuards');
 
 ///editfield <field number> <new value>
 module.exports = {
@@ -18,7 +19,10 @@ module.exports = {
                 .setRequired(false)
         ),
     async execute(interaction) {
-            await interaction.deferReply({ flags: 64 });
+        if (!(await ensureAdminInteraction(interaction))) {
+            return;
+        }
+        await interaction.deferReply({ flags: 64 });
         const fieldNumber = interaction.options.getInteger('fieldnumber');
         let newValue;
         if (interaction.options.getString('newvalue') == null) {

--- a/commands/adminCommands/editincomemenu.js
+++ b/commands/adminCommands/editincomemenu.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder } = require('discord.js');
 const admin = require('../../admin'); // Importing the database manager
+const { ensureAdminInteraction } = require('../../shared/interactionGuards');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -12,7 +13,10 @@ module.exports = {
                 .setRequired(true)
         ),
     async execute(interaction) {
-            await interaction.deferReply({ flags: 64 });
+        if (!(await ensureAdminInteraction(interaction))) {
+            return;
+        }
+        await interaction.deferReply({ flags: 64 });
         const role = interaction.options.getString('income');
         const numericID = interaction.user.id;
 

--- a/commands/adminCommands/embed.js
+++ b/commands/adminCommands/embed.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder } = require('discord.js');
 const admin = require('../../admin'); // Importing the database manager
+const { ensureAdminInteraction } = require('../../shared/interactionGuards');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -20,6 +21,9 @@ module.exports = {
                 .setDescription('The name of the embed')
                 .setRequired(true)),
 	async execute(interaction) {
+	    if (!(await ensureAdminInteraction(interaction))) {
+	        return;
+	    }
 	        await interaction.deferReply({ flags: 64 });
 		try {
             let type = interaction.options.getString('type');

--- a/commands/adminCommands/embedlist.js
+++ b/commands/adminCommands/embedlist.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder } = require('discord.js');
 const admin = require('../../admin'); // Importing the database manager
+const { ensureAdminInteraction } = require('../../shared/interactionGuards');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -16,6 +17,9 @@ module.exports = {
                     {name: 'Guide', value: 'guide'}))
 		.setDefaultMemberPermissions(0),
 	async execute(interaction) {
+	    if (!(await ensureAdminInteraction(interaction))) {
+	        return;
+	    }
 	        await interaction.deferReply({ flags: 64 });
 		try {
             let reply;

--- a/commands/adminCommands/guide.js
+++ b/commands/adminCommands/guide.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder } = require('discord.js');
 const admin = require('../../admin'); // Importing the database manager
+const { ensureAdminInteraction } = require('../../shared/interactionGuards');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -10,8 +11,11 @@ module.exports = {
 			.setDescription('The guide name')
 			.setRequired(true)
 		),
-	async execute(interaction) {
-	        await interaction.deferReply({ flags: 64 });
+        async execute(interaction) {
+                if (!(await ensureAdminInteraction(interaction))) {
+                        return;
+                }
+                await interaction.deferReply({ flags: 64 });
 		const guideName = interaction.options.getString('guide');
 
 		(async () => {

--- a/commands/adminCommands/initclassselectmenu.js
+++ b/commands/adminCommands/initclassselectmenu.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder } = require('discord.js');
 const admin = require('../../admin'); // Importing the database manager
+const { ensureAdminInteraction } = require('../../shared/interactionGuards');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -7,6 +8,9 @@ module.exports = {
 		.setDescription('Initialize a class select menu here')
 		.setDefaultMemberPermissions(0),
 	async execute(interaction) {
+	    if (!(await ensureAdminInteraction(interaction))) {
+	        return;
+	    }
 	        await interaction.deferReply({ flags: 64 });
 		try {
             // Call the method with the channel object directly

--- a/commands/adminCommands/initpartyselectmenus.js
+++ b/commands/adminCommands/initpartyselectmenus.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder } = require('discord.js');
 const admin = require('../../admin'); // Importing the database manager
+const { ensureAdminInteraction } = require('../../shared/interactionGuards');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -7,6 +8,9 @@ module.exports = {
 		.setDescription('Initialize the menus to join a party')
 		.setDefaultMemberPermissions(0),
 	async execute(interaction) {
+	    if (!(await ensureAdminInteraction(interaction))) {
+	        return;
+	    }
 	        await interaction.deferReply({ flags: 64 });
 		try {
             // Call the method with the channel object directly

--- a/commands/adminCommands/initresourceselectmenu.js
+++ b/commands/adminCommands/initresourceselectmenu.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder } = require('discord.js');
 const admin = require('../../admin'); // Importing the database manager
+const { ensureAdminInteraction } = require('../../shared/interactionGuards');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -7,6 +8,9 @@ module.exports = {
 		.setDescription('Initialize a resource select menu here')
 		.setDefaultMemberPermissions(0),
 	async execute(interaction) {
+	    if (!(await ensureAdminInteraction(interaction))) {
+	        return;
+	    }
 	        await interaction.deferReply({ flags: 64 });
 		try {
             // Call the method with the channel object directly

--- a/commands/adminCommands/initshireselectmenu.js
+++ b/commands/adminCommands/initshireselectmenu.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder } = require('discord.js');
 const admin = require('../../admin'); // Importing the database manager
+const { ensureAdminInteraction } = require('../../shared/interactionGuards');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -12,6 +13,9 @@ module.exports = {
             )
 		.setDefaultMemberPermissions(0),
 	async execute(interaction) {
+	    if (!(await ensureAdminInteraction(interaction))) {
+	        return;
+	    }
 	        await interaction.deferReply({ flags: 64 });
 		try {
             // Call the method with the channel object directly

--- a/commands/adminCommands/inittradenodeselectmenu.js
+++ b/commands/adminCommands/inittradenodeselectmenu.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder } = require('discord.js');
 const admin = require('../../admin'); // Importing the database manager
+const { ensureAdminInteraction } = require('../../shared/interactionGuards');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -7,6 +8,9 @@ module.exports = {
 		.setDescription('Initialize a trade node select menu here')
 		.setDefaultMemberPermissions(0),
 	async execute(interaction) {
+	    if (!(await ensureAdminInteraction(interaction))) {
+	        return;
+	    }
 	        await interaction.deferReply({ flags: 64 });
 		try {
             // Call the method with the channel object directly

--- a/commands/adminCommands/listplayerkingdoms.js
+++ b/commands/adminCommands/listplayerkingdoms.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder } = require('discord.js');
 const admin = require('../../admin'); // Importing the database manager
+const { ensureAdminInteraction } = require('../../shared/interactionGuards');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -7,7 +8,10 @@ module.exports = {
         .setDescription('List all kingdoms owned by a player')
         .setDefaultMemberPermissions(0),
     async execute(interaction) {
-            await interaction.deferReply({ flags: 64 });
+        if (!(await ensureAdminInteraction(interaction))) {
+            return;
+        }
+        await interaction.deferReply({ flags: 64 });
         try {
             let reply = await admin.listKingdoms();
             //Reply is an embed

--- a/commands/adminCommands/lore.js
+++ b/commands/adminCommands/lore.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder } = require('discord.js');
 const admin = require('../../admin'); // Importing the database manager
+const { ensureAdminInteraction } = require('../../shared/interactionGuards');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -10,8 +11,11 @@ module.exports = {
 			.setDescription('The lore name')
 			.setRequired(true)
 		),
-	async execute(interaction) {
-	        await interaction.deferReply({ flags: 64 });
+        async execute(interaction) {
+                if (!(await ensureAdminInteraction(interaction))) {
+                        return;
+                }
+                await interaction.deferReply({ flags: 64 });
 		const loreName = interaction.options.getString('lore');
 
 		(async () => {

--- a/commands/adminCommands/rank.js
+++ b/commands/adminCommands/rank.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder } = require('discord.js');
 const admin = require('../../admin'); // Importing the database manager
+const { ensureAdminInteraction } = require('../../shared/interactionGuards');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -10,8 +11,11 @@ module.exports = {
 			.setDescription('The rank name')
 			.setRequired(true)
 		),
-	async execute(interaction) {
-	        await interaction.deferReply({ flags: 64 });
+        async execute(interaction) {
+                if (!(await ensureAdminInteraction(interaction))) {
+                        return;
+                }
+                await interaction.deferReply({ flags: 64 });
 		const rankName = interaction.options.getString('rank');
 
 		(async () => {

--- a/commands/adminCommands/removeembed.js
+++ b/commands/adminCommands/removeembed.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder } = require('discord.js');
 const admin = require('../../admin'); // Importing the database manager
+const { ensureAdminInteraction } = require('../../shared/interactionGuards');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -21,6 +22,9 @@ module.exports = {
                     {name: 'Rank', value: 'rank'},
                     {name: 'Guide', value: 'guide'})),
 	async execute(interaction) {
+	    if (!(await ensureAdminInteraction(interaction))) {
+	        return;
+	    }
 	        await interaction.deferReply({ flags: 64 });
 		const mapName = interaction.options.getString('embed');
 		const type = interaction.options.getString('type');

--- a/commands/adminCommands/removeincome.js
+++ b/commands/adminCommands/removeincome.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder } = require('discord.js');
 const shop = require('../../shop'); // Importing the database manager
+const { ensureAdminInteraction } = require('../../shared/interactionGuards');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -12,7 +13,10 @@ module.exports = {
             .setRequired(true)
         ),
     async execute(interaction) {
-            await interaction.deferReply({ flags: 64 });
+        if (!(await ensureAdminInteraction(interaction))) {
+            return;
+        }
+        await interaction.deferReply({ flags: 64 });
         const itemName = interaction.options.getString('income');
 
         (async () => {

--- a/commands/adminCommands/removerecipe.js
+++ b/commands/adminCommands/removerecipe.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder } = require('discord.js');
 const shop = require('../../shop'); // Importing the database manager
+const { ensureAdminInteraction } = require('../../shared/interactionGuards');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -12,6 +13,9 @@ module.exports = {
 			.setRequired(true)
 		),
 	async execute(interaction) {
+	    if (!(await ensureAdminInteraction(interaction))) {
+	        return;
+	    }
 	        await interaction.deferReply({ flags: 64 });
 		const itemName = interaction.options.getString('recipe');
 

--- a/commands/charCommands/additemstoplayer.js
+++ b/commands/charCommands/additemstoplayer.js
@@ -1,3 +1,4 @@
+const { ensureAdminInteraction } = require('../../shared/interactionGuards');
 //Admin command
 
 const { SlashCommandBuilder } = require('discord.js');
@@ -12,7 +13,10 @@ module.exports = {
         .addStringOption(option => option.setName('item').setDescription('The item to add').setRequired(true))
         .addIntegerOption(option => option.setName('amount').setDescription('The amount of items to add').setRequired(true)),
     async execute(interaction) {
-            await interaction.deferReply({ flags: 64 });
+        if (!(await ensureAdminInteraction(interaction))) {
+            return;
+        }
+        await interaction.deferReply({ flags: 64 });
         const player = interaction.options.getUser('player').id;
         const item = interaction.options.getString('item');
         const amount = interaction.options.getInteger('amount');

--- a/commands/charCommands/additemstorole.js
+++ b/commands/charCommands/additemstorole.js
@@ -1,3 +1,4 @@
+const { ensureAdminInteraction } = require('../../shared/interactionGuards');
 //Admin command
 
 const { SlashCommandBuilder } = require('discord.js');
@@ -12,7 +13,10 @@ module.exports = {
         .addStringOption(option => option.setName('item').setDescription('The item to add').setRequired(true))
         .addIntegerOption(option => option.setName('amount').setDescription('The amount of items to add').setRequired(true)),
     async execute(interaction) {
-            await interaction.deferReply({ flags: 64 });
+        if (!(await ensureAdminInteraction(interaction))) {
+            return;
+        }
+        await interaction.deferReply({ flags: 64 });
         const role = interaction.options.getRole('role');
         const item = interaction.options.getString('item');
         const amount = interaction.options.getInteger('amount');

--- a/commands/charCommands/addplayergold.js
+++ b/commands/charCommands/addplayergold.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder } = require('discord.js');
 const char = require('../../char'); // Importing the database manager
+const { ensureAdminInteraction } = require('../../shared/interactionGuards');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -9,7 +10,10 @@ module.exports = {
         .addIntegerOption(option => option.setName('gold').setDescription('The amount of gold to set').setRequired(true))
         .setDefaultMemberPermissions(0),
     async execute(interaction) {
-            await interaction.deferReply({ flags: 64 });
+        if (!(await ensureAdminInteraction(interaction))) {
+            return;
+        }
+        await interaction.deferReply({ flags: 64 });
         const player = interaction.options.getUser('player').id;
         const gold = interaction.options.getInteger('gold');
         const response = await char.addPlayerGold(player, gold);

--- a/commands/charCommands/balanceadmin.js
+++ b/commands/charCommands/balanceadmin.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder } = require('discord.js');
 const char = require('../../char'); // Importing the database manager
+const { ensureAdminInteraction } = require('../../shared/interactionGuards');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -8,6 +9,9 @@ module.exports = {
         .addUserOption(option => option.setName('player').setDescription('The player to show the balance of').setRequired(true))
         .setDefaultMemberPermissions(0),
         async execute(interaction) {
+            if (!(await ensureAdminInteraction(interaction))) {
+                return;
+            }
                 await interaction.deferReply({ flags: 64 });
                 const charID = interaction.options.getUser('player').id;
 

--- a/commands/charCommands/balanceall.js
+++ b/commands/charCommands/balanceall.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder } = require('discord.js');
 const char = require('../../char'); // Importing the database manager
+const { ensureAdminInteraction } = require('../../shared/interactionGuards');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -7,6 +8,9 @@ module.exports = {
 		.setDescription('Show balance of all players')
         .setDefaultMemberPermissions(0),
 	async execute(interaction) {
+	    if (!(await ensureAdminInteraction(interaction))) {
+	        return;
+	    }
 	        await interaction.deferReply({ flags: 64 });
 
 		(async () => {

--- a/commands/charCommands/changeplayerstats.js
+++ b/commands/charCommands/changeplayerstats.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder } = require('discord.js');
 const char = require('../../char'); // Importing the database manager
+const { ensureAdminInteraction } = require('../../shared/interactionGuards');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -16,7 +17,10 @@ module.exports = {
         .addIntegerOption(option => option.setName('value').setDescription('The value to change stat by').setRequired(true))
         .setDefaultMemberPermissions(0),
     async execute(interaction) {
-            await interaction.deferReply({ flags: 64 });
+        if (!(await ensureAdminInteraction(interaction))) {
+            return;
+        }
+        await interaction.deferReply({ flags: 64 });
         const player = interaction.options.getUser('player').id;
         const stat = interaction.options.getString('stat');
         const value = interaction.options.getInteger('value');

--- a/commands/charCommands/charadmin.js
+++ b/commands/charCommands/charadmin.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder } = require('discord.js');
 const char = require('../../char'); // Importing the database manager
+const { ensureAdminInteraction } = require('../../shared/interactionGuards');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -12,6 +13,9 @@ module.exports = {
 				.setRequired(true)
 		),
         async execute(interaction) {
+            if (!(await ensureAdminInteraction(interaction))) {
+                return;
+            }
                 await interaction.deferReply({ flags: 64 });
                 const charID = interaction.options.getUser('character').id;
 

--- a/commands/charCommands/setplayergold.js
+++ b/commands/charCommands/setplayergold.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder } = require('discord.js');
 const char = require('../../char'); // Importing the database manager
+const { ensureAdminInteraction } = require('../../shared/interactionGuards');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -9,7 +10,10 @@ module.exports = {
         .addIntegerOption(option => option.setName('gold').setDescription('The amount of gold to set').setRequired(true))
         .setDefaultMemberPermissions(0),
     async execute(interaction) {
-            await interaction.deferReply({ flags: 64 });
+        if (!(await ensureAdminInteraction(interaction))) {
+            return;
+        }
+        await interaction.deferReply({ flags: 64 });
         const player = interaction.options.getUser('player').id;
         const gold = interaction.options.getInteger('gold');
         const response = await char.setPlayerGold(player, gold);

--- a/commands/charCommands/takeitemsfromplayer.js
+++ b/commands/charCommands/takeitemsfromplayer.js
@@ -1,3 +1,4 @@
+const { ensureAdminInteraction } = require('../../shared/interactionGuards');
 //Admin command
 
 const { SlashCommandBuilder } = require('discord.js');
@@ -12,7 +13,10 @@ module.exports = {
         .addStringOption(option => option.setName('item').setDescription('The item to take').setRequired(true))
         .addIntegerOption(option => option.setName('amount').setDescription('The amount of items to take').setRequired(true)),
     async execute(interaction) {
-            await interaction.deferReply({ flags: 64 });
+        if (!(await ensureAdminInteraction(interaction))) {
+            return;
+        }
+        await interaction.deferReply({ flags: 64 });
         const player = interaction.options.getUser('player').id;
         const item = interaction.options.getString('item');
         const amount = interaction.options.getInteger('amount');

--- a/commands/charCommands/transfergold.js
+++ b/commands/charCommands/transfergold.js
@@ -1,3 +1,4 @@
+const { ensureAdminInteraction } = require('../../shared/interactionGuards');
 //Admin command
 
 const { SlashCommandBuilder } = require('discord.js');
@@ -13,7 +14,10 @@ module.exports = {
         .addUserOption(option => option.setName('playergetting').setDescription('The player to give gold to').setRequired(true))
         .addIntegerOption(option => option.setName('amount').setDescription('The amount of gold to give').setRequired(true)),
     async execute(interaction) {
-            await interaction.deferReply({ flags: 64 });
+        if (!(await ensureAdminInteraction(interaction))) {
+            return;
+        }
+        await interaction.deferReply({ flags: 64 });
         const playerGiving = interaction.options.getUser('playergiving').id;
         const player = interaction.options.getUser('playergetting').id;
         const amount = interaction.options.getInteger('amount');

--- a/commands/charCommands/warn.js
+++ b/commands/charCommands/warn.js
@@ -1,4 +1,5 @@
-//Admin command
+const { ensureRoleInteraction } = require('../../shared/interactionGuards');
+//Moderator command
 
 const { SlashCommandBuilder } = require('discord.js');
 const char = require('../../char'); // Importing the database manager
@@ -10,7 +11,10 @@ module.exports = {
         .setDefaultMemberPermissions(0)
         .addUserOption(option => option.setName('player').setDescription('The player to warn').setRequired(true)),
     async execute(interaction) {
-            await interaction.deferReply({ flags: 64 });
+        if (!(await ensureRoleInteraction(interaction, 'Moderator'))) {
+            return;
+        }
+        await interaction.deferReply({ flags: 64 });
         const player = interaction.options.getUser('player').id;
         const response = await char.warn(player);
 

--- a/commands/shopCommands/additem.js
+++ b/commands/shopCommands/additem.js
@@ -1,3 +1,4 @@
+const { ensureAdminInteraction } = require('../../shared/interactionGuards');
 //ADMIN COMMAND
 const { SlashCommandBuilder, ActionRowBuilder, ModalBuilder, TextInputBuilder, TextInputStyle } = require('discord.js');
 const shop = require('../../shop'); // Importing shop
@@ -13,6 +14,9 @@ module.exports = {
 		.addStringOption(option => option.setName('itemcategory').setDescription('The category of the item').setRequired(true))
 		.addStringOption(option => option.setName('itemprice').setDescription('The price of the item').setRequired(false)),
 	async execute(interaction) {
+	    if (!(await ensureAdminInteraction(interaction))) {
+	        return;
+	    }
 	        await interaction.deferReply({ flags: 64 });
 		// Call the addItem function from the Shop class with the collected information
 		if (parseInt(interaction.options.getString('itemprice'))) {

--- a/commands/shopCommands/additemmodal.js
+++ b/commands/shopCommands/additemmodal.js
@@ -1,3 +1,4 @@
+const { ensureAdminInteraction } = require('../../shared/interactionGuards');
 //ADMIN COMMAND
 const { SlashCommandBuilder, ActionRowBuilder, ModalBuilder, TextInputBuilder, TextInputStyle } = require('discord.js');
 //const shop = require('../../shop'); // Importing shop
@@ -8,6 +9,9 @@ module.exports = {
 		.setDescription('Add item to shop')
 		.setDefaultMemberPermissions(0),
 	async execute(interaction) {
+	    if (!(await ensureAdminInteraction(interaction))) {
+	        return;
+	    }
 		// Create the modal
 		const modal = new ModalBuilder()
 			.setCustomId('additemmodal')

--- a/commands/shopCommands/addrecipe.js
+++ b/commands/shopCommands/addrecipe.js
@@ -1,3 +1,4 @@
+const { ensureAdminInteraction } = require('../../shared/interactionGuards');
 //ADMIN COMMAND
 const { SlashCommandBuilder, ActionRowBuilder, ModalBuilder, TextInputBuilder, TextInputStyle } = require('discord.js');
 const shop = require('../../shop');
@@ -12,7 +13,10 @@ module.exports = {
             .setDescription('The name of the recipe')
             .setRequired(false)),
     async execute(interaction) {
-            await interaction.deferReply({ flags: 64 });
+        if (!(await ensureAdminInteraction(interaction))) {
+            return;
+        }
+        await interaction.deferReply({ flags: 64 });
         let recipeName = interaction.options.getString('recipename');
         if (!recipeName) {
             recipeName = 'New Recipe';

--- a/commands/shopCommands/allitems.js
+++ b/commands/shopCommands/allitems.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder } = require('discord.js');
 const shop = require('../../shop'); // Importing the database manager
+const { ensureAdminInteraction } = require('../../shared/interactionGuards');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -7,6 +8,9 @@ module.exports = {
 		.setDefaultMemberPermissions(0)
 		.setDescription('List all items'),
 	async execute(interaction) {
+	    if (!(await ensureAdminInteraction(interaction))) {
+	        return;
+	    }
 	        await interaction.deferReply({ flags: 64 });
                 // const itemListString = await shop.shop();
                 // await interaction.editReply(itemListString);

--- a/commands/shopCommands/edititemfield.js
+++ b/commands/shopCommands/edititemfield.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder } = require('discord.js');
 const shop = require('../../shop'); // Importing the database manager
+const { ensureAdminInteraction } = require('../../shared/interactionGuards');
 
 ///editfield <field number> <new value>
 module.exports = {
@@ -18,7 +19,10 @@ module.exports = {
                 .setRequired(false)
         ),
     async execute(interaction) {
-            await interaction.deferReply({ flags: 64 });
+        if (!(await ensureAdminInteraction(interaction))) {
+            return;
+        }
+        await interaction.deferReply({ flags: 64 });
         const fieldNumber = interaction.options.getInteger('fieldnumber');
         const newValue = interaction.options.getString('newvalue');
 

--- a/commands/shopCommands/edititemmenu.js
+++ b/commands/shopCommands/edititemmenu.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder } = require('discord.js');
 const shop = require('../../shop'); // Importing the database manager
+const { ensureAdminInteraction } = require('../../shared/interactionGuards');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -12,7 +13,10 @@ module.exports = {
                 .setRequired(true)
         ),
     async execute(interaction) {
-            await interaction.deferReply({ flags: 64 });
+        if (!(await ensureAdminInteraction(interaction))) {
+            return;
+        }
+        await interaction.deferReply({ flags: 64 });
         const itemName = interaction.options.getString('itemname');
         const numericID = interaction.user.id;
         const reply = await shop.editItemMenu(itemName, 1, String(numericID));

--- a/commands/shopCommands/editrecipefield.js
+++ b/commands/shopCommands/editrecipefield.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder } = require('discord.js');
 const shop = require('../../shop'); // Importing the database manager
+const { ensureAdminInteraction } = require('../../shared/interactionGuards');
 
 ///editfield <field number> <new value>
 module.exports = {
@@ -18,7 +19,10 @@ module.exports = {
                 .setRequired(false)
         ),
     async execute(interaction) {
-            await interaction.deferReply({ flags: 64 });
+        if (!(await ensureAdminInteraction(interaction))) {
+            return;
+        }
+        await interaction.deferReply({ flags: 64 });
         const fieldNumber = interaction.options.getInteger('fieldnumber');
         const newValue = interaction.options.getString('newvalue');
         const numericID = interaction.user.id;

--- a/commands/shopCommands/editrecipemenu.js
+++ b/commands/shopCommands/editrecipemenu.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder } = require('discord.js');
 const shop = require('../../shop'); // Importing the database manager
+const { ensureAdminInteraction } = require('../../shared/interactionGuards');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -12,6 +13,9 @@ module.exports = {
 			.setRequired(true)
 		),
 	async execute(interaction) {
+	    if (!(await ensureAdminInteraction(interaction))) {
+	        return;
+	    }
 	        await interaction.deferReply({ flags: 64 });
                 const recipeName = interaction.options.getString('recipename');
 

--- a/commands/shopCommands/inventoryadmin.js
+++ b/commands/shopCommands/inventoryadmin.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder } = require('discord.js');
 const shop = require('../../shop'); // Importing the database manager
+const { ensureAdminInteraction } = require('../../shared/interactionGuards');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -12,6 +13,9 @@ module.exports = {
 				.setRequired(true)
 		),
 	async execute(interaction) {
+	    if (!(await ensureAdminInteraction(interaction))) {
+	        return;
+	    }
 	        await interaction.deferReply({ flags: 64 });
         const userID = interaction.options.getUser('user').id;
 		var replyEmbed = await shop.createInventoryEmbed(userID);

--- a/commands/shopCommands/removeitem.js
+++ b/commands/shopCommands/removeitem.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder } = require('discord.js');
 const shop = require('../../shop'); // Importing the database manager
+const { ensureAdminInteraction } = require('../../shared/interactionGuards');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -12,6 +13,9 @@ module.exports = {
 			.setRequired(true)
 		),
 	async execute(interaction) {
+	    if (!(await ensureAdminInteraction(interaction))) {
+	        return;
+	    }
 	        await interaction.deferReply({ flags: 64 });
 		const itemName = interaction.options.getString('itemname');
 

--- a/commands/shopCommands/renamecategory.js
+++ b/commands/shopCommands/renamecategory.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder } = require('discord.js');
 const shop = require('../../shop'); // Importing the database manager
+const { ensureAdminInteraction } = require('../../shared/interactionGuards');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -17,6 +18,9 @@ module.exports = {
             .setRequired(true)
         ),
 	async execute(interaction) {
+	    if (!(await ensureAdminInteraction(interaction))) {
+	        return;
+	    }
 	        await interaction.deferReply({ flags: 64 });
         const category = interaction.options.getString('category');
         const newCategory = interaction.options.getString('newcategory');

--- a/commands/shopCommands/updateAllItemVersions.js
+++ b/commands/shopCommands/updateAllItemVersions.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder } = require('discord.js');
 const shop = require('../../shop'); // Importing the database manager
+const { ensureAdminInteraction } = require('../../shared/interactionGuards');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -7,6 +8,9 @@ module.exports = {
 		.setDescription('Update the version of all items')
 		.setDefaultMemberPermissions(0),
 	async execute(interaction) {
+	    if (!(await ensureAdminInteraction(interaction))) {
+	        return;
+	    }
 	        await interaction.deferReply({ flags: 64 });
 		(async () => {
 			try {

--- a/commands/shopCommands/updateItemVersion.js
+++ b/commands/shopCommands/updateItemVersion.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder } = require('discord.js');
 const shop = require('../../shop'); // Importing the database manager
+const { ensureAdminInteraction } = require('../../shared/interactionGuards');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -12,6 +13,9 @@ module.exports = {
 			.setRequired(true)
 		),
 	async execute(interaction) {
+	    if (!(await ensureAdminInteraction(interaction))) {
+	        return;
+	    }
 	        await interaction.deferReply({ flags: 64 });
 		const itemName = interaction.options.getString('itemname');
 

--- a/shared/interactionGuards.js
+++ b/shared/interactionGuards.js
@@ -1,0 +1,59 @@
+const { PermissionFlagsBits } = require('discord.js');
+
+async function replyOrFollowUp(interaction, payload) {
+    if (interaction.replied || interaction.deferred) {
+        await interaction.followUp(payload);
+    } else {
+        await interaction.reply(payload);
+    }
+}
+
+async function ensureGuildContext(interaction) {
+    if (interaction.inGuild && interaction.inGuild()) {
+        return true;
+    }
+    if (interaction.guild) {
+        return true;
+    }
+    await replyOrFollowUp(interaction, {
+        content: 'This command can only be used within a server.',
+        ephemeral: true,
+    });
+    return false;
+}
+
+async function ensureAdminInteraction(interaction) {
+    if (!(await ensureGuildContext(interaction))) {
+        return false;
+    }
+    if (interaction.memberPermissions?.has(PermissionFlagsBits.Administrator)) {
+        return true;
+    }
+    await replyOrFollowUp(interaction, {
+        content: 'You do not have permission to use this command.',
+        ephemeral: true,
+    });
+    return false;
+}
+
+async function ensureRoleInteraction(interaction, roleName) {
+    if (!(await ensureGuildContext(interaction))) {
+        return false;
+    }
+    const member = interaction.member;
+    const hasRole = member?.roles?.cache?.some(role => role.name === roleName || role.id === roleName);
+    if (hasRole) {
+        return true;
+    }
+    await replyOrFollowUp(interaction, {
+        content: `You must have the ${roleName} role to use this command.`,
+        ephemeral: true,
+    });
+    return false;
+}
+
+module.exports = {
+    ensureAdminInteraction,
+    ensureRoleInteraction,
+    ensureGuildContext,
+};


### PR DESCRIPTION
## Summary
- ignore direct messages and non-guild interactions so commands only execute in servers
- add shared permission helpers to centralize admin and moderator gating
- update all privileged slash commands to require administrator or moderator access before running

## Testing
- Not run (requires Discord bot token)


------
https://chatgpt.com/codex/tasks/task_e_68e4c9ac43dc832e9aaa1ca8ca55971e